### PR TITLE
fix: restore electron about dialog

### DIFF
--- a/packages/about-view/src/parts/GetConfigJsonPath/GetConfigJsonPath.ts
+++ b/packages/about-view/src/parts/GetConfigJsonPath/GetConfigJsonPath.ts
@@ -1,5 +1,5 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 
 export const getConfigJsonPath = async (): Promise<string> => {
-  return RendererWorker.invoke('ProcessPaths.getConfigJsonPath')
+  return RendererWorker.invoke('PlatformPaths.getConfigJsonPath')
 }

--- a/packages/about-view/test/GetConfigJsonPath.test.ts
+++ b/packages/about-view/test/GetConfigJsonPath.test.ts
@@ -4,11 +4,11 @@ import * as GetConfigJsonPath from '../src/parts/GetConfigJsonPath/GetConfigJson
 
 test('getConfigJsonPath', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
-    'ProcessPaths.getConfigJsonPath'(): string {
+    'PlatformPaths.getConfigJsonPath'(): string {
       return 'config.json'
     },
   })
 
   expect(await GetConfigJsonPath.getConfigJsonPath()).toBe('config.json')
-  expect(mockRpc.invocations).toEqual([['ProcessPaths.getConfigJsonPath']])
+  expect(mockRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
 })

--- a/packages/about-view/test/LoadConfig.test.ts
+++ b/packages/about-view/test/LoadConfig.test.ts
@@ -6,7 +6,7 @@ import * as LoadConfig from '../src/parts/LoadConfig/LoadConfig.ts'
 
 const registerConfigJsonPathMock = (): ReturnType<typeof RendererWorker.registerMockRpc> => {
   return RendererWorker.registerMockRpc({
-    'ProcessPaths.getConfigJsonPath'(): string {
+    'PlatformPaths.getConfigJsonPath'(): string {
       return 'config.json'
     },
   })
@@ -41,7 +41,7 @@ test('loadConfig', async () => {
     productName: 'Test Editor',
     version: '1.2.3',
   })
-  expect(mockRendererRpc.invocations).toEqual([['ProcessPaths.getConfigJsonPath']])
+  expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })
 
@@ -69,6 +69,6 @@ test('loadConfig - missing values', async () => {
     productName: '',
     version: '',
   })
-  expect(mockRendererRpc.invocations).toEqual([['ProcessPaths.getConfigJsonPath']])
+  expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })

--- a/packages/about-view/test/LoadContent2.test.ts
+++ b/packages/about-view/test/LoadContent2.test.ts
@@ -16,7 +16,7 @@ beforeAll(() => {
 
 const registerConfigJsonPathMock = (): ReturnType<typeof RendererWorker.registerMockRpc> => {
   return RendererWorker.registerMockRpc({
-    'ProcessPaths.getConfigJsonPath'(): string {
+    'PlatformPaths.getConfigJsonPath'(): string {
       return 'config.json'
     },
   })
@@ -81,7 +81,7 @@ test('loadContent2 - useNewLoadConfig', async () => {
     uid: 1,
     useNewLoadConfig: true,
   })
-  expect(mockRendererRpc.invocations).toEqual([['ProcessPaths.getConfigJsonPath']])
+  expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })
 
@@ -113,7 +113,7 @@ test('loadContent2 - useNewLoadConfig falls back to current values', async () =>
     uid: 1,
     useNewLoadConfig: true,
   })
-  expect(mockRendererRpc.invocations).toEqual([['ProcessPaths.getConfigJsonPath']])
+  expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })
 
@@ -145,6 +145,6 @@ test('loadContent2 - useNewLoadConfig falls back to current values for invalid c
     uid: 1,
     useNewLoadConfig: true,
   })
-  expect(mockRendererRpc.invocations).toEqual([['ProcessPaths.getConfigJsonPath']])
+  expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })

--- a/packages/about-view/test/ShowAbout.test.ts
+++ b/packages/about-view/test/ShowAbout.test.ts
@@ -29,6 +29,9 @@ test('showAbout - electron platform', async () => {
     'GetWindowId.getWindowId'(): number {
       return 1
     },
+    'PlatformPaths.getConfigJsonPath'(): string {
+      return 'config.json'
+    },
     'Process.getChromeVersion'(): string {
       return '123.0.0'
     },
@@ -40,9 +43,6 @@ test('showAbout - electron platform', async () => {
     },
     'Process.getV8Version'(): string {
       return '10.0.0'
-    },
-    'ProcessPaths.getConfigJsonPath'(): string {
-      return 'config.json'
     },
   })
   await ShowAbout.showAbout(PlatformType.Electron)

--- a/packages/about-view/test/ShowAboutElectron.test.ts
+++ b/packages/about-view/test/ShowAboutElectron.test.ts
@@ -25,6 +25,9 @@ test('showAboutElectron - clicks ok button', async () => {
     'GetWindowId.getWindowId'(): number {
       return 1
     },
+    'PlatformPaths.getConfigJsonPath'(): string {
+      return 'config.json'
+    },
     'Process.getChromeVersion'(): string {
       return 'x'
     },
@@ -45,9 +48,6 @@ test('showAboutElectron - clicks ok button', async () => {
     },
     'Process.getVersion'(): string {
       return '0.0.0-dev'
-    },
-    'ProcessPaths.getConfigJsonPath'(): string {
-      return 'config.json'
     },
   })
 
@@ -93,6 +93,9 @@ test('showAboutElectron - clicks copy button', async () => {
     'GetWindowId.getWindowId'(): number {
       return 1
     },
+    'PlatformPaths.getConfigJsonPath'(): string {
+      return 'config.json'
+    },
     'Process.getChromeVersion'(): string {
       return 'x'
     },
@@ -113,9 +116,6 @@ test('showAboutElectron - clicks copy button', async () => {
     },
     'Process.getVersion'(): string {
       return '0.0.0-dev'
-    },
-    'ProcessPaths.getConfigJsonPath'(): string {
-      return 'config.json'
     },
   })
 


### PR DESCRIPTION
Fix the About worker config-path RPC to call the renderer command that is actually registered. This restores the Electron About dialog and keeps its product/version detail loading covered by the existing tests.