### PR TITLE
feature: migrate build package to typescript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
-        run: echo "value=$(node packages/build/src/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        run: echo "value=$(node packages/build/src/computeNodeModulesCacheKey.ts)" >> $GITHUB_OUTPUT
         shell: bash
       - uses: actions/cache@v4
         id: npm-cache

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
-        run: echo "value=$(node packages/build/src/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        run: echo "value=$(node packages/build/src/computeNodeModulesCacheKey.ts)" >> $GITHUB_OUTPUT
         shell: bash
       - uses: actions/cache@v4
         id: npm-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
-        run: echo "value=$(node packages/build/src/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        run: echo "value=$(node packages/build/src/computeNodeModulesCacheKey.ts)" >> $GITHUB_OUTPUT
         shell: bash
       - uses: actions/cache@v4
         id: npm-cache

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "author": "Lvce Editor",
   "type": "module",
   "scripts": {
-    "build": "node packages/build/src/build.js",
+    "build": "node packages/build/src/build.ts",
     "build:static": "node packages/build/src/build-static.ts",
     "build:watch": "./packages/build/node_modules/.bin/esbuild --format=esm --bundle --external:node:buffer --external:electron --external:ws --external:node:worker_threads --bundle --watch packages/about-view/src/aboutWorkerMain.ts --outfile=.tmp/dist/dist/aboutWorkerMain.js",
-    "dev": "node packages/build/src/dev.js",
+    "dev": "node packages/build/src/dev.ts",
     "e2e": "cd packages/e2e && npm run e2e",
     "e2e:firefox": "cd packages/e2e && npm run e2e:firefox",
     "e2e:firefox:headless": "cd packages/e2e && npm run e2e:firefox:headless",

--- a/packages/build/src/build-static.ts
+++ b/packages/build/src/build-static.ts
@@ -1,7 +1,7 @@
 import { cp, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { root } from './root.js'
+import { root } from './root.ts'
 
 const sharedProcessPath = join(root, 'packages', 'server', 'node_modules', '@lvce-editor', 'shared-process', 'index.js')
 

--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -1,21 +1,21 @@
 import { execa } from 'execa'
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { bundleJs } from './bundleJs.js'
-import { root } from './root.js'
+import { bundleJs } from './bundleJs.ts'
+import { root } from './root.ts'
 
 const dist = join(root, '.tmp', 'dist')
 
-const readJson = async (path) => {
+const readJson = async (path: string): Promise<any> => {
   const content = await readFile(path, 'utf8')
   return JSON.parse(content)
 }
 
-const writeJson = async (path, json) => {
+const writeJson = async (path: string, json: any): Promise<void> => {
   await writeFile(path, JSON.stringify(json, null, 2) + '\n')
 }
 
-const getGitTagFromGit = async () => {
+const getGitTagFromGit = async (): Promise<string> => {
   const { stdout, stderr, exitCode } = await execa('git', ['describe', '--exact-match', '--tags'], {
     reject: false,
   })
@@ -31,7 +31,7 @@ const getGitTagFromGit = async () => {
   return stdout
 }
 
-const getVersion = async () => {
+const getVersion = async (): Promise<string> => {
   const { env } = process
   const { RG_VERSION, GIT_TAG } = env
   if (RG_VERSION) {

--- a/packages/build/src/bundleJs.ts
+++ b/packages/build/src/bundleJs.ts
@@ -2,13 +2,10 @@ import pluginTypeScript from '@babel/preset-typescript'
 import { babel } from '@rollup/plugin-babel'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import { join } from 'path'
-import { rollup } from 'rollup'
-import { root } from './root.js'
+import { rollup, type RollupOptions } from 'rollup'
+import { root } from './root.ts'
 
-/**
- * @type {import('rollup').RollupOptions}
- */
-const options = {
+const options: RollupOptions = {
   input: join(root, 'packages/about-view/src/aboutWorkerMain.ts'),
   preserveEntrySignatures: 'strict',
   treeshake: {
@@ -34,7 +31,7 @@ const options = {
   ],
 }
 
-export const bundleJs = async () => {
+export const bundleJs = async (): Promise<void> => {
   const input = await rollup(options)
   // @ts-ignore
   await input.write(options.output)

--- a/packages/build/src/computeNodeModulesCacheKey.ts
+++ b/packages/build/src/computeNodeModulesCacheKey.ts
@@ -2,10 +2,10 @@ import { createHash } from 'node:crypto'
 import { readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { root } from './root.js'
+import { root } from './root.ts'
 
-const getPackageLocations = () => {
-  const packageLocations = []
+const getPackageLocations = (): string[] => {
+  const packageLocations: string[] = []
   const packagesFolder = join(root, 'packages')
   const dirents = readdirSync(packagesFolder)
   for (const dirent of dirents) {
@@ -15,13 +15,13 @@ const getPackageLocations = () => {
   return packageLocations
 }
 
-const locations = [
+const locations: string[] = [
   'lerna.json',
   ...getPackageLocations(),
   '.github/workflows/pr.yml',
   '.github/workflows/ci.yml',
   '.github/workflows/release.yml',
-  'packages/build/src/computeNodeModulesCacheKey.js',
+  'packages/build/src/computeNodeModulesCacheKey.ts',
   'packages/server/src/postinstall.js',
 ]
 
@@ -32,15 +32,15 @@ for (const dirent of dirents) {
   locations.push(`packages/${dirent}/package-lock.json`)
 }
 
-const getAbsolutePath = (relativePath) => {
+const getAbsolutePath = (relativePath: string): string => {
   return join(root, relativePath)
 }
 
-const getContent = (absolutePath) => {
+const getContent = (absolutePath: string): Promise<string> => {
   return readFile(absolutePath, 'utf8')
 }
 
-export const computeHash = (contents) => {
+export const computeHash = (contents: string | string[]): string => {
   const hash = createHash('sha1')
   if (Array.isArray(contents)) {
     for (const content of contents) {
@@ -52,14 +52,14 @@ export const computeHash = (contents) => {
   return hash.digest('hex')
 }
 
-const computeCacheKey = async (locations) => {
+const computeCacheKey = async (locations: string[]): Promise<string> => {
   const absolutePaths = locations.map(getAbsolutePath)
   const contents = await Promise.all(absolutePaths.map(getContent))
   const hash = computeHash(contents)
   return hash
 }
 
-const main = async () => {
+const main = async (): Promise<void> => {
   const hash = await computeCacheKey(locations)
   process.stdout.write(hash)
 }

--- a/packages/build/src/dev.ts
+++ b/packages/build/src/dev.ts
@@ -1,7 +1,7 @@
 import { execa } from 'execa'
-import { root } from './root.js'
+import { root } from './root.ts'
 
-const main = async () => {
+const main = async (): Promise<void> => {
   execa(`npm`, ['run', 'build:watch'], {
     cwd: root,
     stdio: 'inherit',

--- a/packages/build/src/root.ts
+++ b/packages/build/src/root.ts
@@ -3,4 +3,4 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-export const root = join(__dirname, '..', '..', '..')
+export const root: string = join(__dirname, '..', '..', '..')


### PR DESCRIPTION
## Summary

- migrate the remaining build package modules from JavaScript to TypeScript
- update package scripts and CI cache-key commands to use the TypeScript entry points
- use explicit TypeScript imports throughout the build package