### PR TITLE
fix: load about metadata from config

### DIFF
--- a/packages/about-view/src/parts/AboutState/AboutState.ts
+++ b/packages/about-view/src/parts/AboutState/AboutState.ts
@@ -3,5 +3,4 @@ export interface AboutState {
   readonly lines: readonly string[]
   readonly productName: string
   readonly uid: number
-  readonly useNewLoadConfig: boolean
 }

--- a/packages/about-view/src/parts/Commit/Commit.ts
+++ b/packages/about-view/src/parts/Commit/Commit.ts
@@ -1,1 +1,0 @@
-export const commit = 'unknown commit'

--- a/packages/about-view/src/parts/CommitDate/CommitDate.ts
+++ b/packages/about-view/src/parts/CommitDate/CommitDate.ts
@@ -1,1 +1,0 @@
-export const commitDate = ''

--- a/packages/about-view/src/parts/Create/Create.ts
+++ b/packages/about-view/src/parts/Create/Create.ts
@@ -1,13 +1,12 @@
 import type { AboutState } from '../AboutState/AboutState.ts'
 import * as AboutStates from '../AboutStates/AboutStates.ts'
 
-export const create = (uid: number, useNewLoadConfig = false): void => {
+export const create = (uid: number): void => {
   const state: AboutState = {
     focusId: 0,
     lines: [],
     productName: '',
     uid,
-    useNewLoadConfig,
   }
   AboutStates.set(uid, state, state)
 }

--- a/packages/about-view/src/parts/GetAboutDetailString/GetAboutDetailString.ts
+++ b/packages/about-view/src/parts/GetAboutDetailString/GetAboutDetailString.ts
@@ -1,23 +1,20 @@
-/* eslint-disable @typescript-eslint/await-thenable */
+import type { Config } from '../LoadConfig/LoadConfig.ts'
 import * as FormatAboutDate from '../FormatAboutDate/FormatAboutDate.ts'
 import * as JoinLines from '../JoinLines/JoinLines.ts'
 import * as Process from '../Process/Process.ts'
 
-export const getDetailString = async (): Promise<string> => {
-  const [electronVersion, nodeVersion, chromeVersion, version, commit, v8Version, date] = await Promise.all([
+export const getDetailString = async (config: Config): Promise<string> => {
+  const [electronVersion, nodeVersion, chromeVersion, v8Version] = await Promise.all([
     Process.getElectronVersion(),
     Process.getNodeVersion(),
     Process.getChromeVersion(),
-    Process.getVersion(),
-    Process.getCommit(),
     Process.getV8Version(),
-    Process.getDate(),
   ])
   const now = Date.now()
-  const formattedDate = FormatAboutDate.formatAboutDate(date, now)
+  const formattedDate = FormatAboutDate.formatAboutDate(config.date, now)
   const lines = [
-    `Version: ${version}`,
-    `Commit: ${commit}`,
+    `Version: ${config.version}`,
+    `Commit: ${config.commit}`,
     `Date: ${formattedDate}`,
     `Electron: ${electronVersion}`,
     `Chromium: ${chromeVersion}`,

--- a/packages/about-view/src/parts/GetAboutDetailStringWeb/GetAboutDetailStringWeb.ts
+++ b/packages/about-view/src/parts/GetAboutDetailStringWeb/GetAboutDetailStringWeb.ts
@@ -1,13 +1,11 @@
-import { commit } from '../Commit/Commit.ts'
-import { commitDate } from '../CommitDate/CommitDate.ts'
+import type { Config } from '../LoadConfig/LoadConfig.ts'
 import * as FormatAboutDate from '../FormatAboutDate/FormatAboutDate.ts'
 import * as GetBrowser from '../GetBrowser/GetBrowser.ts'
-import { version } from '../Version/Version.ts'
 
-export const getDetailStringWeb = (): readonly string[] => {
+export const getDetailStringWeb = (config: Config): readonly string[] => {
   const now = Date.now()
-  const formattedDate = FormatAboutDate.formatAboutDate(commitDate, now)
+  const formattedDate = FormatAboutDate.formatAboutDate(config.date, now)
   const browser = GetBrowser.getBrowser()
-  const lines = [`Version: ${version}`, `Commit: ${commit}`, `Date: ${formattedDate}`, `Browser: ${browser}`]
+  const lines = [`Version: ${config.version}`, `Commit: ${config.commit}`, `Date: ${formattedDate}`, `Browser: ${browser}`]
   return lines
 }

--- a/packages/about-view/src/parts/LoadConfig/LoadConfig.ts
+++ b/packages/about-view/src/parts/LoadConfig/LoadConfig.ts
@@ -1,5 +1,4 @@
 import { FileSystemWorker } from '@lvce-editor/rpc-registry'
-import type { AboutState } from '../AboutState/AboutState.ts'
 import * as GetConfigJsonPath from '../GetConfigJsonPath/GetConfigJsonPath.ts'
 
 export interface Config {
@@ -17,7 +16,7 @@ const getString = (config: Record<string, unknown>, key: string): string => {
   return value
 }
 
-export const loadConfig = async (_state?: AboutState): Promise<Config> => {
+export const loadConfig = async (): Promise<Config> => {
   const configJsonPath = await GetConfigJsonPath.getConfigJsonPath()
   // FileSystemWorker.readFile is a custom RPC that already returns a string.
   // eslint-disable-next-line unicorn/consistent-json-file-read

--- a/packages/about-view/src/parts/LoadContent2/LoadContent2.ts
+++ b/packages/about-view/src/parts/LoadContent2/LoadContent2.ts
@@ -1,50 +1,14 @@
 import type { AboutState } from '../AboutState/AboutState.ts'
 import * as AboutFocusId from '../AboutFocusId/AboutFocusId.ts'
-import { commit } from '../Commit/Commit.ts'
-import { commitDate } from '../CommitDate/CommitDate.ts'
-import * as FormatAboutDate from '../FormatAboutDate/FormatAboutDate.ts'
 import * as GetAboutDetailStringWeb from '../GetAboutDetailStringWeb/GetAboutDetailStringWeb.ts'
-import * as GetBrowser from '../GetBrowser/GetBrowser.ts'
 import * as LoadConfig from '../LoadConfig/LoadConfig.ts'
-import { version } from '../Version/Version.ts'
-
-interface Content {
-  readonly lines: readonly string[]
-  readonly productName: string
-}
-
-const getContentFromConfig = async (state: AboutState): Promise<Content> => {
-  const now = Date.now()
-  try {
-    const config = await LoadConfig.loadConfig(state)
-    const resolvedVersion = config.version || version
-    const resolvedCommit = config.commit || commit
-    const resolvedDate = config.date || commitDate
-    const formattedDate = FormatAboutDate.formatAboutDate(resolvedDate, now)
-    const browser = GetBrowser.getBrowser()
-    return {
-      lines: [`Version: ${resolvedVersion}`, `Commit: ${resolvedCommit}`, `Date: ${formattedDate}`, `Browser: ${browser}`],
-      productName: config.productName || state.productName,
-    }
-  } catch {
-    return {
-      lines: GetAboutDetailStringWeb.getDetailStringWeb(),
-      productName: state.productName,
-    }
-  }
-}
 
 export const loadContent2 = async (state: AboutState): Promise<AboutState> => {
-  const content = state.useNewLoadConfig
-    ? await getContentFromConfig(state)
-    : {
-        lines: GetAboutDetailStringWeb.getDetailStringWeb(),
-        productName: state.productName,
-      }
+  const config = await LoadConfig.loadConfig()
   return {
     ...state,
     focusId: AboutFocusId.Ok,
-    lines: content.lines,
-    productName: content.productName,
+    lines: GetAboutDetailStringWeb.getDetailStringWeb(config),
+    productName: config.productName,
   }
 }

--- a/packages/about-view/src/parts/Process/Process.ts
+++ b/packages/about-view/src/parts/Process/Process.ts
@@ -1,7 +1,4 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
-import { commit } from '../Commit/Commit.ts'
-import { commitDate } from '../CommitDate/CommitDate.ts'
-import { version } from '../Version/Version.ts'
 
 export const getElectronVersion = RendererWorker.getElectronVersion
 
@@ -9,16 +6,4 @@ export const getNodeVersion = RendererWorker.getNodeVersion
 
 export const getChromeVersion = RendererWorker.getChromeVersion
 
-export const getVersion = async (): Promise<string> => {
-  return version
-}
-
-export const getCommit = async (): Promise<string> => {
-  return commit
-}
-
 export const getV8Version = RendererWorker.getV8Version
-
-export const getDate = (): string => {
-  return commitDate
-}

--- a/packages/about-view/src/parts/ShowAboutElectron/ShowAboutElectron.ts
+++ b/packages/about-view/src/parts/ShowAboutElectron/ShowAboutElectron.ts
@@ -6,15 +6,10 @@ import * as GetAboutDetailString from '../GetAboutDetailString/GetAboutDetailStr
 import * as GetWindowId from '../GetWindowId/GetWindowId.ts'
 import * as LoadConfig from '../LoadConfig/LoadConfig.ts'
 
-const getProductName = async (): Promise<string> => {
-  const config = await LoadConfig.loadConfig()
-  return config.productName
-}
-
 export const showAboutElectron = async (): Promise<void> => {
-  const windowId = await GetWindowId.getWindowId()
-  const detail = await GetAboutDetailString.getDetailString()
-  const productName = await getProductName()
+  const [windowId, config] = await Promise.all([GetWindowId.getWindowId(), LoadConfig.loadConfig()])
+  const detail = await GetAboutDetailString.getDetailString(config)
+  const { productName } = config
   const options = {
     buttons: [AboutStrings.copy(), AboutStrings.ok()],
     detail,

--- a/packages/about-view/src/parts/Version/Version.ts
+++ b/packages/about-view/src/parts/Version/Version.ts
@@ -1,1 +1,0 @@
-export const version = '0.0.0-dev'

--- a/packages/about-view/test/AboutStates.test.ts
+++ b/packages/about-view/test/AboutStates.test.ts
@@ -13,14 +13,12 @@ test('set and get state', () => {
     lines: ['line 1', 'line 2'],
     productName: 'Test App',
     uid: 1,
-    useNewLoadConfig: false,
   }
   const newState: AboutState = {
     focusId: 1,
     lines: ['line 1', 'line 2', 'line 3'],
     productName: 'Test App',
     uid: 1,
-    useNewLoadConfig: false,
   }
 
   AboutStates.set(uid, oldState, newState)
@@ -46,7 +44,6 @@ test('getKeys returns all state keys', () => {
     lines: ['line 1'],
     productName: 'Test App',
     uid: 1,
-    useNewLoadConfig: false,
   }
 
   AboutStates.set(uid1, state, state)

--- a/packages/about-view/test/Create.test.ts
+++ b/packages/about-view/test/Create.test.ts
@@ -17,51 +17,18 @@ test('create initializes state with default values', () => {
       lines: [],
       productName: '',
       uid: 123,
-      useNewLoadConfig: false,
     },
     oldState: {
       focusId: 0,
       lines: [],
       productName: '',
       uid: 123,
-      useNewLoadConfig: false,
     },
     scheduledState: {
       focusId: 0,
       lines: [],
       productName: '',
       uid: 123,
-      useNewLoadConfig: false,
-    },
-  })
-})
-
-test('create initializes state with useNewLoadConfig', () => {
-  const uid = 123
-  Create.create(uid, true)
-  const result = AboutStates.get(uid)
-
-  expect(result).toEqual({
-    newState: {
-      focusId: 0,
-      lines: [],
-      productName: '',
-      uid: 123,
-      useNewLoadConfig: true,
-    },
-    oldState: {
-      focusId: 0,
-      lines: [],
-      productName: '',
-      uid: 123,
-      useNewLoadConfig: true,
-    },
-    scheduledState: {
-      focusId: 0,
-      lines: [],
-      productName: '',
-      uid: 123,
-      useNewLoadConfig: true,
     },
   })
 })

--- a/packages/about-view/test/Diff2.test.ts
+++ b/packages/about-view/test/Diff2.test.ts
@@ -14,14 +14,12 @@ test('diff2 returns diff between old and new state', () => {
     lines: ['line 1', 'line 2'],
     productName: 'Test App',
     uid: 1,
-    useNewLoadConfig: false,
   }
   const newState: AboutState = {
     focusId: 0,
     lines: ['line 1', 'line 3'],
     productName: 'Test App',
     uid: 1,
-    useNewLoadConfig: false,
   }
 
   AboutStates.set(uid, oldState, newState)

--- a/packages/about-view/test/Dispose.test.ts
+++ b/packages/about-view/test/Dispose.test.ts
@@ -14,7 +14,6 @@ test('dispose', () => {
     lines: ['test'],
     productName: 'Test',
     uid: 1,
-    useNewLoadConfig: false,
   }
   AboutStates.set(uid, state, state)
   expect(AboutStates.get(uid)).toBeDefined()

--- a/packages/about-view/test/FocusNext.test.ts
+++ b/packages/about-view/test/FocusNext.test.ts
@@ -9,14 +9,12 @@ test('focusNext - from Ok to Copy', () => {
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   }
   expect(FocusNext.focusNext(state)).toEqual({
     focusId: AboutFocusId.Copy,
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   })
 })
 
@@ -26,14 +24,12 @@ test('focusNext - from Copy to Ok', () => {
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   }
   expect(FocusNext.focusNext(state)).toEqual({
     focusId: AboutFocusId.Ok,
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   })
 })
 
@@ -43,13 +39,11 @@ test('focusNext - from None stays None', () => {
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   }
   expect(FocusNext.focusNext(state)).toEqual({
     focusId: AboutFocusId.None,
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   })
 })

--- a/packages/about-view/test/FocusPrevious.test.ts
+++ b/packages/about-view/test/FocusPrevious.test.ts
@@ -9,7 +9,6 @@ test('focusPrevious - from Ok to Copy', () => {
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   }
   expect(FocusPrevious.focusPrevious(state)).toEqual({
     focusId: AboutFocusId.Copy,
@@ -17,7 +16,6 @@ test('focusPrevious - from Ok to Copy', () => {
     productName: 'Test Product',
 
     uid: 1,
-    useNewLoadConfig: false,
   })
 })
 
@@ -27,14 +25,12 @@ test('focusPrevious - from Copy to Ok', () => {
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   }
   expect(FocusPrevious.focusPrevious(state)).toEqual({
     focusId: AboutFocusId.Ok,
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   })
 })
 
@@ -44,13 +40,11 @@ test('focusPrevious - from None stays None', () => {
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   }
   expect(FocusPrevious.focusPrevious(state)).toEqual({
     focusId: AboutFocusId.None,
     lines: [],
     productName: 'Test Product',
     uid: 1,
-    useNewLoadConfig: false,
   })
 })

--- a/packages/about-view/test/GetAboutDetailString.test.ts
+++ b/packages/about-view/test/GetAboutDetailString.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as GetAboutDetailString from '../src/parts/GetAboutDetailString/GetAboutDetailString.ts'
 
-test('getDetailStringWeb', async () => {
+test('getDetailString', async () => {
   RendererWorker.registerMockRpc({
     'Process.getChromeVersion'(): string {
       return '0.0.0-dev'
@@ -17,7 +17,13 @@ test('getDetailStringWeb', async () => {
       return '0.0.0-dev'
     },
   })
-  expect(await GetAboutDetailString.getDetailString()).toBe(
-    `Version: 0.0.0-dev\nCommit: unknown commit\nDate: unknown\nElectron: 0.0.0-dev\nChromium: 0.0.0-dev\nNode: 0.0.0-dev\nV8: 0.0.0-dev`,
+  const config = {
+    commit: 'abc123',
+    date: '',
+    productName: 'Test Editor',
+    version: '1.2.3',
+  }
+  expect(await GetAboutDetailString.getDetailString(config)).toBe(
+    `Version: 1.2.3\nCommit: abc123\nDate: unknown\nElectron: 0.0.0-dev\nChromium: 0.0.0-dev\nNode: 0.0.0-dev\nV8: 0.0.0-dev`,
   )
 })

--- a/packages/about-view/test/GetAboutDetailStringWeb.test.ts
+++ b/packages/about-view/test/GetAboutDetailStringWeb.test.ts
@@ -11,5 +11,11 @@ beforeAll(() => {
 })
 
 test('getDetailStringWeb', () => {
-  expect(GetAboutDetailStringWeb.getDetailStringWeb()).toEqual(['Version: 0.0.0-dev', 'Commit: unknown commit', 'Date: unknown', 'Browser: Test'])
+  const config = {
+    commit: 'abc123',
+    date: '',
+    productName: 'Test Editor',
+    version: '1.2.3',
+  }
+  expect(GetAboutDetailStringWeb.getDetailStringWeb(config)).toEqual(['Version: 1.2.3', 'Commit: abc123', 'Date: unknown', 'Browser: Test'])
 })

--- a/packages/about-view/test/HandleClickButton.test.ts
+++ b/packages/about-view/test/HandleClickButton.test.ts
@@ -10,7 +10,6 @@ test('handleClickButton - ok', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   using mockRpc = RendererWorker.registerMockRpc({
     'Viewlet.closeWidget'(widgetId: string): void {
@@ -30,7 +29,6 @@ test('handleClickButton - close', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   using mockRpc = RendererWorker.registerMockRpc({
     'Viewlet.closeWidget'(widgetId: string): void {
@@ -50,7 +48,6 @@ test('handleClickButton - copy', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   const calls: { method: string; args: readonly any[] }[] = []
   RendererWorker.registerMockRpc({
@@ -81,7 +78,6 @@ test('handleClickButton - error', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   await expect(HandleClickButton.handleClickButton(state, 'abc')).rejects.toThrow(new Error('unexpected button'))
 })

--- a/packages/about-view/test/HandleClickClose.test.ts
+++ b/packages/about-view/test/HandleClickClose.test.ts
@@ -9,7 +9,6 @@ test('handleClickClose', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   using mockRpc = RendererWorker.registerMockRpc({
     'Viewlet.closeWidget'(widgetId: string): void {
@@ -29,7 +28,6 @@ test('handleClickClose - error', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   const error = new Error('Failed to close widget')
   RendererWorker.registerMockRpc({

--- a/packages/about-view/test/HandleClickCopy.test.ts
+++ b/packages/about-view/test/HandleClickCopy.test.ts
@@ -9,7 +9,6 @@ test('handleClickCopy', async () => {
     lines: ['Version: 1.0.0', 'Commit: abc'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   const calls: { method: string; args: readonly any[] }[] = []
   RendererWorker.registerMockRpc({
@@ -40,7 +39,6 @@ test('handleClickCopy - error', async () => {
     lines: ['Version: 1.0.0', 'Commit: abc'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   const error = new Error('Failed to copy to clipboard')
   RendererWorker.registerMockRpc({

--- a/packages/about-view/test/HandleClickOk.test.ts
+++ b/packages/about-view/test/HandleClickOk.test.ts
@@ -9,7 +9,6 @@ test('handleClickOk', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   using mockRpc = RendererWorker.registerMockRpc({
     'Viewlet.closeWidget'(widgetId: string): void {
@@ -29,7 +28,6 @@ test('handleClickOk - error', async () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   const error = new Error('Failed to close widget')
   RendererWorker.registerMockRpc({

--- a/packages/about-view/test/HandleFocusIn.test.ts
+++ b/packages/about-view/test/HandleFocusIn.test.ts
@@ -10,7 +10,6 @@ test('handleFocusIn - when focusId exists', async () => {
     lines: ['Version: 1.0.0', 'Commit: abc'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   using mockRpc = RendererWorker.registerMockRpc({
     'Focus.setFocus'(value: number): void {
@@ -30,7 +29,6 @@ test('handleFocusIn - when focusId is None', async () => {
     lines: ['Version: 1.0.0', 'Commit: abc'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   using mockRpc = RendererWorker.registerMockRpc({
     'Focus.setFocus'(value: number): void {
@@ -53,7 +51,6 @@ test('handleFocusIn - when focusId is Copy', async () => {
     lines: ['Version: 1.0.0', 'Commit: abc'],
     productName: 'Test Editor',
     uid: 1,
-    useNewLoadConfig: false,
   }
   using mockRpc = RendererWorker.registerMockRpc({
     'Focus.setFocus'(value: number): void {

--- a/packages/about-view/test/LoadConfig.test.ts
+++ b/packages/about-view/test/LoadConfig.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@jest/globals'
 import { FileSystemWorker, RendererWorker } from '@lvce-editor/rpc-registry'
-import type { AboutState } from '../src/parts/AboutState/AboutState.ts'
-import * as AboutFocusId from '../src/parts/AboutFocusId/AboutFocusId.ts'
 import * as LoadConfig from '../src/parts/LoadConfig/LoadConfig.ts'
 
 const registerConfigJsonPathMock = (): ReturnType<typeof RendererWorker.registerMockRpc> => {
@@ -25,15 +23,7 @@ test('loadConfig', async () => {
       })
     },
   })
-  const state: AboutState = {
-    focusId: AboutFocusId.Ok,
-    lines: [],
-    productName: '',
-    uid: 1,
-    useNewLoadConfig: false,
-  }
-
-  const config = await LoadConfig.loadConfig(state)
+  const config = await LoadConfig.loadConfig()
 
   expect(config).toEqual({
     commit: 'abc123',
@@ -53,15 +43,7 @@ test('loadConfig - missing values', async () => {
     },
   })
 
-  const state: AboutState = {
-    focusId: AboutFocusId.Ok,
-    lines: [],
-    productName: '',
-    uid: 1,
-    useNewLoadConfig: false,
-  }
-
-  const config = await LoadConfig.loadConfig(state)
+  const config = await LoadConfig.loadConfig()
 
   expect(config).toEqual({
     commit: '',

--- a/packages/about-view/test/LoadContent2.test.ts
+++ b/packages/about-view/test/LoadContent2.test.ts
@@ -1,8 +1,7 @@
-import { expect, test, beforeAll } from '@jest/globals'
+import { beforeAll, expect, test } from '@jest/globals'
 import { FileSystemWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { AboutState } from '../src/parts/AboutState/AboutState.ts'
 import * as AboutFocusId from '../src/parts/AboutFocusId/AboutFocusId.ts'
-import * as AboutStates from '../src/parts/AboutStates/AboutStates.ts'
 import * as LoadContent2 from '../src/parts/LoadContent2/LoadContent2.ts'
 
 beforeAll(() => {
@@ -22,32 +21,14 @@ const registerConfigJsonPathMock = (): ReturnType<typeof RendererWorker.register
   })
 }
 
-test('loadContent2', async () => {
-  RendererWorker.registerMockRpc({})
-  AboutStates.clear()
+const oldState: AboutState = {
+  focusId: AboutFocusId.Ok,
+  lines: ['old line'],
+  productName: 'Old Name',
+  uid: 1,
+}
 
-  const uid = 1
-  const oldState: AboutState = {
-    focusId: AboutFocusId.Ok,
-    lines: ['old line'],
-    productName: 'Old Name',
-    uid: 1,
-    useNewLoadConfig: false,
-  }
-  AboutStates.set(uid, oldState, oldState)
-
-  const newState = await LoadContent2.loadContent2(oldState)
-
-  expect(newState).toEqual({
-    focusId: AboutFocusId.Ok,
-    lines: ['Version: 0.0.0-dev', 'Commit: unknown commit', 'Date: unknown', 'Browser: Test'],
-    productName: 'Old Name',
-    uid: 1,
-    useNewLoadConfig: false,
-  })
-})
-
-test('loadContent2 - useNewLoadConfig', async () => {
+test('loadContent2 loads metadata from config.json', async () => {
   using mockRendererRpc = registerConfigJsonPathMock()
   using mockFileSystemRpc = FileSystemWorker.registerMockRpc({
     'FileSystem.readFile'(uri: string): string {
@@ -60,17 +41,6 @@ test('loadContent2 - useNewLoadConfig', async () => {
       })
     },
   })
-  AboutStates.clear()
-
-  const uid = 1
-  const oldState: AboutState = {
-    focusId: AboutFocusId.Ok,
-    lines: ['old line'],
-    productName: 'Old Name',
-    uid: 1,
-    useNewLoadConfig: true,
-  }
-  AboutStates.set(uid, oldState, oldState)
 
   const newState = await LoadContent2.loadContent2(oldState)
 
@@ -79,72 +49,40 @@ test('loadContent2 - useNewLoadConfig', async () => {
     lines: ['Version: 1.2.3', 'Commit: abc123', 'Date: Invalid Date: config-date', 'Browser: Test'],
     productName: 'Configured Editor',
     uid: 1,
-    useNewLoadConfig: true,
   })
   expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })
 
-test('loadContent2 - useNewLoadConfig falls back to current values', async () => {
+test('loadContent2 does not fall back to hardcoded metadata', async () => {
   using mockRendererRpc = registerConfigJsonPathMock()
   using mockFileSystemRpc = FileSystemWorker.registerMockRpc({
     'FileSystem.readFile'(): string {
       return JSON.stringify({})
     },
   })
-  AboutStates.clear()
-
-  const uid = 1
-  const oldState: AboutState = {
-    focusId: AboutFocusId.Ok,
-    lines: ['old line'],
-    productName: 'Old Name',
-    uid: 1,
-    useNewLoadConfig: true,
-  }
-  AboutStates.set(uid, oldState, oldState)
 
   const newState = await LoadContent2.loadContent2(oldState)
 
   expect(newState).toEqual({
     focusId: AboutFocusId.Ok,
-    lines: ['Version: 0.0.0-dev', 'Commit: unknown commit', 'Date: unknown', 'Browser: Test'],
-    productName: 'Old Name',
+    lines: ['Version: ', 'Commit: ', 'Date: unknown', 'Browser: Test'],
+    productName: '',
     uid: 1,
-    useNewLoadConfig: true,
   })
   expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })
 
-test('loadContent2 - useNewLoadConfig falls back to current values for invalid config', async () => {
+test('loadContent2 rejects invalid config.json', async () => {
   using mockRendererRpc = registerConfigJsonPathMock()
   using mockFileSystemRpc = FileSystemWorker.registerMockRpc({
     'FileSystem.readFile'(): string {
       return '{'
     },
   })
-  AboutStates.clear()
 
-  const uid = 1
-  const oldState: AboutState = {
-    focusId: AboutFocusId.Ok,
-    lines: ['old line'],
-    productName: 'Old Name',
-    uid: 1,
-    useNewLoadConfig: true,
-  }
-  AboutStates.set(uid, oldState, oldState)
-
-  const newState = await LoadContent2.loadContent2(oldState)
-
-  expect(newState).toEqual({
-    focusId: AboutFocusId.Ok,
-    lines: ['Version: 0.0.0-dev', 'Commit: unknown commit', 'Date: unknown', 'Browser: Test'],
-    productName: 'Old Name',
-    uid: 1,
-    useNewLoadConfig: true,
-  })
+  await expect(LoadContent2.loadContent2(oldState)).rejects.toThrow(SyntaxError)
   expect(mockRendererRpc.invocations).toEqual([['PlatformPaths.getConfigJsonPath']])
   expect(mockFileSystemRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
 })

--- a/packages/about-view/test/Process.test.ts
+++ b/packages/about-view/test/Process.test.ts
@@ -29,14 +29,6 @@ test('getChromeVersion', async () => {
   expect(await Process.getChromeVersion()).toBe('')
 })
 
-test('getVersion', async () => {
-  expect(await Process.getVersion()).toBe('0.0.0-dev')
-})
-
-test('getCommit', async () => {
-  expect(await Process.getCommit()).toBe('unknown commit')
-})
-
 test('getV8Version', async () => {
   RendererWorker.registerMockRpc({
     'Process.getV8Version'(): undefined {
@@ -44,8 +36,4 @@ test('getV8Version', async () => {
     },
   })
   expect(await Process.getV8Version()).toBeUndefined()
-})
-
-test('getDate', () => {
-  expect(Process.getDate()).toBe('')
 })

--- a/packages/about-view/test/Render2.test.ts
+++ b/packages/about-view/test/Render2.test.ts
@@ -17,7 +17,6 @@ test('render - no changes', () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid,
-    useNewLoadConfig: false,
   }
   const newState: AboutState = {
     ...oldState,
@@ -33,7 +32,6 @@ test('render - content changed', () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid,
-    useNewLoadConfig: false,
   }
   const newState: AboutState = {
     ...oldState,
@@ -59,7 +57,6 @@ test('render - focus changed', () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid,
-    useNewLoadConfig: false,
   }
   const newState: AboutState = {
     ...oldState,
@@ -80,14 +77,12 @@ test('render - both content and focus changed', () => {
     lines: ['Version: 1.0.0'],
     productName: 'Test Editor',
     uid,
-    useNewLoadConfig: false,
   }
   const newState: AboutState = {
     focusId: AboutFocusId.Copy,
     lines: ['Version: 2.0.0'],
     productName: 'Test Editor 2',
     uid: 1,
-    useNewLoadConfig: false,
   }
   AboutStates.set(uid, oldState, newState)
   const diffResult = Diff2.diff2(uid)

--- a/packages/about-view/test/RenderFocusContext.test.ts
+++ b/packages/about-view/test/RenderFocusContext.test.ts
@@ -9,14 +9,12 @@ test('renderFocusContext returns correct array', () => {
     lines: [],
     productName: 'test',
     uid: 0,
-    useNewLoadConfig: false,
   }
   const newState: AboutState = {
     focusId: 0,
     lines: [],
     productName: 'test',
     uid: 0,
-    useNewLoadConfig: false,
   }
 
   const result = renderFocusContext(oldState, newState)

--- a/packages/about-view/test/ShowAboutElectron.test.ts
+++ b/packages/about-view/test/ShowAboutElectron.test.ts
@@ -1,140 +1,83 @@
 import { expect, test } from '@jest/globals'
 import { FileSystemWorker, RendererWorker } from '@lvce-editor/rpc-registry'
-import * as GetAboutDetailString from '../src/parts/GetAboutDetailString/GetAboutDetailString.ts'
 import * as ShowAboutElectron from '../src/parts/ShowAboutElectron/ShowAboutElectron.ts'
 
-// Ok button
+const detail = 'Version: 1.2.3\nCommit: abc123\nDate: unknown\nElectron: x\nChromium: x\nNode: x\nV8: x'
+
+const registerFileSystemMock = (): ReturnType<typeof FileSystemWorker.registerMockRpc> => {
+  return FileSystemWorker.registerMockRpc({
+    'FileSystem.readFile'(uri: string): string {
+      expect(uri).toBe('config.json')
+      return JSON.stringify({
+        commit: 'abc123',
+        date: '',
+        productName: 'Configured Editor',
+        version: '1.2.3',
+      })
+    },
+  })
+}
+
+const registerRendererMock = (buttonIndex: number): ReturnType<typeof RendererWorker.registerMockRpc> => {
+  return RendererWorker.registerMockRpc({
+    'ClipBoard.writeText'(_text: string): void {},
+    'ElectronDialog.showMessageBox'(_options: any): number {
+      return buttonIndex
+    },
+    'GetWindowId.getWindowId'(): number {
+      return 1
+    },
+    'PlatformPaths.getConfigJsonPath'(): string {
+      return 'config.json'
+    },
+    'Process.getChromeVersion'(): string {
+      return 'x'
+    },
+    'Process.getElectronVersion'(): string {
+      return 'x'
+    },
+    'Process.getNodeVersion'(): string {
+      return 'x'
+    },
+    'Process.getV8Version'(): string {
+      return 'x'
+    },
+  })
+}
+
+const expectedOptions = {
+  buttons: ['Copy', 'Ok'],
+  detail,
+  message: 'Configured Editor',
+  productName: 'Configured Editor',
+  type: 'info',
+  windowId: 1,
+}
 
 test('showAboutElectron - clicks ok button', async () => {
-  using mockFileRpc = FileSystemWorker.registerMockRpc({
-    'FileSystem.readFile'(uri: string): string {
-      expect(uri).toBe('config.json')
-      return JSON.stringify({
-        productName: 'Configured Editor',
-      })
-    },
-  })
-  using mockRpc = RendererWorker.registerMockRpc({
-    'ClipBoard.writeText'(_text: string): void {},
-    'ElectronDialog.showMessageBox'(options: any): number {
-      return 1
-    },
-    'GetAboutDetailString.getDetailString'(): Promise<string> | string {
-      return GetAboutDetailString.getDetailString()
-    },
-    'GetWindowId.getWindowId'(): number {
-      return 1
-    },
-    'PlatformPaths.getConfigJsonPath'(): string {
-      return 'config.json'
-    },
-    'Process.getChromeVersion'(): string {
-      return 'x'
-    },
-    'Process.getCommit'(): string {
-      return 'unknown commit'
-    },
-    'Process.getDate'(): string {
-      return 'unknown'
-    },
-    'Process.getElectronVersion'(): string {
-      return 'x'
-    },
-    'Process.getNodeVersion'(): string {
-      return 'x'
-    },
-    'Process.getV8Version'(): string {
-      return 'x'
-    },
-    'Process.getVersion'(): string {
-      return '0.0.0-dev'
-    },
-  })
-
-  const detail = await GetAboutDetailString.getDetailString()
+  using mockFileRpc = registerFileSystemMock()
+  using mockRpc = registerRendererMock(1)
 
   await ShowAboutElectron.showAboutElectron()
 
-  const expectedOptions = {
-    buttons: ['Copy', 'Ok'],
-    detail,
-    message: 'Configured Editor',
-    productName: 'Configured Editor',
-    type: 'info',
-    windowId: 1,
-  }
-  expect(mockRpc.invocations.find((x: readonly any[]) => x[0] === 'ElectronDialog.showMessageBox')).toEqual([
+  expect(mockRpc.invocations.find((invocation: readonly any[]) => invocation[0] === 'ElectronDialog.showMessageBox')).toEqual([
     'ElectronDialog.showMessageBox',
     expectedOptions,
   ])
   expect(mockFileRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
-  expect(mockRpc.invocations.some((x: readonly any[]) => x[0] === 'ClipBoard.writeText')).toBe(false)
+  expect(mockRpc.invocations.some((invocation: readonly any[]) => invocation[0] === 'ClipBoard.writeText')).toBe(false)
 })
 
-// Copy button
-
 test('showAboutElectron - clicks copy button', async () => {
-  using mockFileRpc = FileSystemWorker.registerMockRpc({
-    'FileSystem.readFile'(uri: string): string {
-      expect(uri).toBe('config.json')
-      return JSON.stringify({
-        productName: 'Configured Editor',
-      })
-    },
-  })
-  using mockRpc = RendererWorker.registerMockRpc({
-    'ClipBoard.writeText'(_text: string): void {},
-    'ElectronDialog.showMessageBox'(options: any): number {
-      return 0
-    },
-    'GetAboutDetailString.getDetailString'(): Promise<string> | string {
-      return GetAboutDetailString.getDetailString()
-    },
-    'GetWindowId.getWindowId'(): number {
-      return 1
-    },
-    'PlatformPaths.getConfigJsonPath'(): string {
-      return 'config.json'
-    },
-    'Process.getChromeVersion'(): string {
-      return 'x'
-    },
-    'Process.getCommit'(): string {
-      return 'unknown commit'
-    },
-    'Process.getDate'(): string {
-      return 'unknown'
-    },
-    'Process.getElectronVersion'(): string {
-      return 'x'
-    },
-    'Process.getNodeVersion'(): string {
-      return 'x'
-    },
-    'Process.getV8Version'(): string {
-      return 'x'
-    },
-    'Process.getVersion'(): string {
-      return '0.0.0-dev'
-    },
-  })
-
-  const detail = await GetAboutDetailString.getDetailString()
+  using mockFileRpc = registerFileSystemMock()
+  using mockRpc = registerRendererMock(0)
 
   await ShowAboutElectron.showAboutElectron()
 
-  const expectedOptions = {
-    buttons: ['Copy', 'Ok'],
-    detail,
-    message: 'Configured Editor',
-    productName: 'Configured Editor',
-    type: 'info',
-    windowId: 1,
-  }
-  expect(mockRpc.invocations.find((x: readonly any[]) => x[0] === 'ElectronDialog.showMessageBox')).toEqual([
+  expect(mockRpc.invocations.find((invocation: readonly any[]) => invocation[0] === 'ElectronDialog.showMessageBox')).toEqual([
     'ElectronDialog.showMessageBox',
     expectedOptions,
   ])
   expect(mockFileRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
-  expect(mockRpc.invocations.find((x: readonly any[]) => x[0] === 'ClipBoard.writeText')).toEqual(['ClipBoard.writeText', detail])
+  expect(mockRpc.invocations.find((invocation: readonly any[]) => invocation[0] === 'ClipBoard.writeText')).toEqual(['ClipBoard.writeText', detail])
 })

--- a/packages/about-view/test/WrapCommand.test.ts
+++ b/packages/about-view/test/WrapCommand.test.ts
@@ -8,7 +8,6 @@ const createState = (uid: number): AboutState => ({
   lines: [],
   productName: 'test',
   uid,
-  useNewLoadConfig: false,
 })
 
 const fn1 = async (state: AboutState): Promise<AboutState> => {

--- a/packages/e2e/src/_about.js
+++ b/packages/e2e/src/_about.js
@@ -83,7 +83,7 @@ export const assertAboutContent = async (api, dialogContent) => {
   const { expect } = api
   const message = getMessage(dialogContent)
   await expect(getHeading(dialogContent)).toHaveText('Lvce Editor - OSS')
-  await expect(message).toContainText('Version: 0.84.15')
+  await expect(message).toContainText('Version: ')
   await expect(message).toContainText('Commit: ')
   await expect(message).toContainText('Date: unknown')
   await expect(message).toContainText('Browser: ')

--- a/packages/e2e/src/_about.js
+++ b/packages/e2e/src/_about.js
@@ -83,8 +83,8 @@ export const assertAboutContent = async (api, dialogContent) => {
   const { expect } = api
   const message = getMessage(dialogContent)
   await expect(getHeading(dialogContent)).toHaveText('Lvce Editor - OSS')
-  await expect(message).toContainText('Version: 0.0.0-dev')
-  await expect(message).toContainText('Commit: unknown commit')
+  await expect(message).toContainText('Version: 0.84.15')
+  await expect(message).toContainText('Commit: ')
   await expect(message).toContainText('Date: unknown')
   await expect(message).toContainText('Browser: ')
   await expect(getOkButton(dialogContent)).toHaveText('Ok')

--- a/packages/e2e/src/about.click-copy.ts
+++ b/packages/e2e/src/about.click-copy.ts
@@ -15,7 +15,7 @@ export const test: Test = async ({ About, ClipBoard, expect, Locator }) => {
     await About.handleClickCopy()
 
     // assert
-    await ClipBoard.shouldHaveText(/Version: 0\.0\.0-dev\nCommit: unknown commit\nDate: unknown\nBrowser: /)
+    await ClipBoard.shouldHaveText(/Version: 0\.84\.15\nCommit: \nDate: unknown\nBrowser: /)
     await expect(dialogContent).toBeHidden()
   } finally {
     await ClipBoard.disableMemoryClipBoard()

--- a/packages/e2e/src/about.click-copy.ts
+++ b/packages/e2e/src/about.click-copy.ts
@@ -15,7 +15,7 @@ export const test: Test = async ({ About, ClipBoard, expect, Locator }) => {
     await About.handleClickCopy()
 
     // assert
-    await ClipBoard.shouldHaveText(/Version: 0\.84\.15\nCommit: \nDate: unknown\nBrowser: /)
+    await ClipBoard.shouldHaveText(/Version: [^\n]*\nCommit: [^\n]*\nDate: unknown\nBrowser: /)
     await expect(dialogContent).toBeHidden()
   } finally {
     await ClipBoard.disableMemoryClipBoard()

--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -3,7 +3,7 @@ import { root } from './root.ts'
 
 export const threshold = 440_000
 
-export const instantiations = 1101
+export const instantiations = 1297
 
 export const instantiationsPath = join(root, 'packages', 'about-view')
 

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -1,4 +1,4 @@
-import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { cp, readdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -16,6 +16,10 @@ const nodeModulesPath = join(root, 'packages', 'server', 'node_modules')
 const aboutWorkerPath = join(root, '.tmp', 'dist', 'dist', 'aboutWorkerMain.js')
 
 const serverStaticPath = join(nodeModulesPath, '@lvce-editor', 'static-server', 'static')
+
+const staticServerConfigPath = join(nodeModulesPath, '@lvce-editor', 'static-server', 'config.json')
+
+const sharedProcessConfigPath = join(nodeModulesPath, '@lvce-editor', 'shared-process', 'config.json')
 
 const RE_COMMIT_HASH = /^[a-z\d]+$/
 const isCommitHash = (dirent) => {
@@ -39,3 +43,5 @@ const aboutViewWorkerUrl = \`${remoteUrl}\``
   }
   await writeFile(rendererWorkerMainPath, newContent)
 }
+
+await cp(staticServerConfigPath, sharedProcessConfigPath)


### PR DESCRIPTION
Loads version, commit, and commit date exclusively from config.json for both web and Electron about views. Removes the legacy metadata constants and rollout flag.