### PR TITLE
feature: expand about interaction e2e coverage

### DIFF
--- a/packages/e2e/src/about.click-close.ts
+++ b/packages/e2e/src/about.click-close.ts
@@ -1,5 +1,5 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
-import { openAbout } from './_about.js'
+import { getCloseButton, openAbout } from './_about.js'
 
 export const name = 'about.click-close'
 
@@ -10,7 +10,8 @@ export const test: Test = async ({ About, expect, Locator }) => {
   const dialogContent = await openAbout(aboutApi)
 
   // act
-  await About.handleClickClose()
+  // eslint-disable-next-line e2e/no-direct-click -- verifies the rendered close control is wired to the close command
+  await getCloseButton(dialogContent).click()
 
   // assert
   await expect(dialogContent).toBeHidden()

--- a/packages/e2e/src/about.click-copy.ts
+++ b/packages/e2e/src/about.click-copy.ts
@@ -1,5 +1,5 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
-import { openAbout } from './_about.js'
+import { getCopyButton, openAbout } from './_about.js'
 
 export const name = 'about.click-copy'
 
@@ -12,11 +12,12 @@ export const test: Test = async ({ About, ClipBoard, expect, Locator }) => {
 
   try {
     // act
-    await About.handleClickCopy()
+    // eslint-disable-next-line e2e/no-direct-click -- verifies the rendered Copy button invokes the clipboard action
+    await getCopyButton(dialogContent).click()
 
     // assert
-    await ClipBoard.shouldHaveText(/Version: [^\n]*\nCommit: [^\n]*\nDate: unknown\nBrowser: /)
     await expect(dialogContent).toBeHidden()
+    await ClipBoard.shouldHaveText(/Version: [^\n]*\nCommit: [^\n]*\nDate: unknown\nBrowser: /)
   } finally {
     await ClipBoard.disableMemoryClipBoard()
   }

--- a/packages/e2e/src/about.click-ok.ts
+++ b/packages/e2e/src/about.click-ok.ts
@@ -1,5 +1,5 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
-import { openAbout } from './_about.js'
+import { getOkButton, openAbout } from './_about.js'
 
 export const name = 'about.click-ok'
 
@@ -10,7 +10,8 @@ export const test: Test = async ({ About, expect, Locator }) => {
   const dialogContent = await openAbout(aboutApi)
 
   // act
-  await About.handleClickOk()
+  // eslint-disable-next-line e2e/no-direct-click -- verifies the rendered Ok button is wired to the close command
+  await getOkButton(dialogContent).click()
 
   // assert
   await expect(dialogContent).toBeHidden()

--- a/packages/e2e/src/about.content.ts
+++ b/packages/e2e/src/about.content.ts
@@ -3,8 +3,6 @@ import { assertAboutContent, closeAbout, getMessage, openAbout } from './_about.
 
 export const name = 'about.content'
 
-export const skip = 1
-
 export const test: Test = async (api) => {
   const dialogContent = await openAbout(api)
 

--- a/packages/e2e/src/about.keyboard-shift-tab-wraparound.ts
+++ b/packages/e2e/src/about.keyboard-shift-tab-wraparound.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { closeAbout, getCopyButton, getOkButton, openAbout, waitForFocused } from './_about.js'
+
+export const name = 'about.keyboard-shift-tab-wraparound'
+
+export const test: Test = async ({ About, expect, KeyBoard, Locator }) => {
+  const aboutApi = { About, expect, Locator }
+  const dialogContent = await openAbout(aboutApi)
+
+  try {
+    await KeyBoard.press('Shift+Tab')
+    await waitForFocused(expect, getCopyButton(dialogContent))
+
+    await KeyBoard.press('Shift+Tab')
+    await waitForFocused(expect, getOkButton(dialogContent))
+  } finally {
+    await closeAbout(aboutApi)
+  }
+}

--- a/packages/e2e/src/about.keyboard-tab-wraparound.ts
+++ b/packages/e2e/src/about.keyboard-tab-wraparound.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { closeAbout, getCopyButton, getOkButton, openAbout, waitForFocused } from './_about.js'
+
+export const name = 'about.keyboard-tab-wraparound'
+
+export const test: Test = async ({ About, expect, KeyBoard, Locator }) => {
+  const aboutApi = { About, expect, Locator }
+  const dialogContent = await openAbout(aboutApi)
+
+  try {
+    await KeyBoard.press('Tab')
+    await waitForFocused(expect, getCopyButton(dialogContent))
+
+    await KeyBoard.press('Tab')
+    await waitForFocused(expect, getOkButton(dialogContent))
+  } finally {
+    await closeAbout(aboutApi)
+  }
+}

--- a/packages/e2e/src/about.open.ts
+++ b/packages/e2e/src/about.open.ts
@@ -3,8 +3,6 @@ import { assertAboutContent, closeAbout, openAbout } from './_about.js'
 
 export const name = 'about.open'
 
-export const skip = 1
-
 export const test: Test = async (api) => {
   const dialogContent = await openAbout(api)
   try {


### PR DESCRIPTION
Adds real DOM interaction coverage for the About dialog, restores metadata content tests, and covers keyboard focus wraparound.