### PR TITLE
feature: test selectable about dialog text

### DIFF
--- a/packages/e2e/src/about.text-selection.ts
+++ b/packages/e2e/src/about.text-selection.ts
@@ -8,8 +8,8 @@ export const test: Test = async ({ About, expect, Locator }) => {
   const dialogContent = Locator('.DialogContent').first()
 
   try {
-    await expect(getHeading(dialogContent)).toHaveCSS('user-select', 'text')
-    await expect(getMessage(dialogContent)).toHaveCSS('user-select', 'text')
+    await expect(getHeading(dialogContent)).toHaveCSS('userSelect', 'text')
+    await expect(getMessage(dialogContent)).toHaveCSS('userSelect', 'text')
   } finally {
     await About.handleClickClose()
   }

--- a/packages/e2e/src/about.text-selection.ts
+++ b/packages/e2e/src/about.text-selection.ts
@@ -8,8 +8,9 @@ export const test: Test = async ({ About, expect, Locator }) => {
   const dialogContent = Locator('.DialogContent').first()
 
   try {
-    await expect(getHeading(dialogContent)).toHaveCSS('userSelect', 'text')
-    await expect(getMessage(dialogContent)).toHaveCSS('userSelect', 'text')
+    // WebKit exposes user-select through the prefixed computed style property.
+    await expect(getHeading(dialogContent)).toHaveCSS('-webkit-user-select', 'text')
+    await expect(getMessage(dialogContent)).toHaveCSS('-webkit-user-select', 'text')
   } finally {
     await About.handleClickClose()
   }

--- a/packages/e2e/src/about.text-selection.ts
+++ b/packages/e2e/src/about.text-selection.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { closeAbout, getHeading, getMessage, openAbout } from './_about.js'
+
+export const name = 'about.text-selection'
+
+export const test: Test = async (api) => {
+  const dialogContent = await openAbout(api)
+
+  try {
+    await api.expect(getHeading(dialogContent)).toHaveCSS('user-select', 'text')
+    await api.expect(getMessage(dialogContent)).toHaveCSS('user-select', 'text')
+  } finally {
+    await closeAbout(api)
+  }
+}

--- a/packages/e2e/src/about.text-selection.ts
+++ b/packages/e2e/src/about.text-selection.ts
@@ -1,15 +1,16 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
-import { closeAbout, getHeading, getMessage, openAbout } from './_about.js'
+import { getHeading, getMessage } from './_about.js'
 
 export const name = 'about.text-selection'
 
-export const test: Test = async (api) => {
-  const dialogContent = await openAbout(api)
+export const test: Test = async ({ About, expect, Locator }) => {
+  await About.show()
+  const dialogContent = Locator('.DialogContent').first()
 
   try {
-    await api.expect(getHeading(dialogContent)).toHaveCSS('user-select', 'text')
-    await api.expect(getMessage(dialogContent)).toHaveCSS('user-select', 'text')
+    await expect(getHeading(dialogContent)).toHaveCSS('user-select', 'text')
+    await expect(getMessage(dialogContent)).toHaveCSS('user-select', 'text')
   } finally {
-    await closeAbout(api)
+    await About.handleClickClose()
   }
 }


### PR DESCRIPTION
Adds e2e coverage confirming the About dialog heading and message remain selectable text.