### PR TITLE
feature: test about dialog padding

### DIFF
--- a/packages/e2e/src/about.dialog-content-padding.ts
+++ b/packages/e2e/src/about.dialog-content-padding.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { closeAbout, openAbout } from './_about.js'
+
+export const name = 'about.dialog-content-padding'
+
+export const test: Test = async ({ About, expect, Locator }) => {
+  const aboutApi = { About, expect, Locator }
+  const dialogContent = await openAbout(aboutApi)
+
+  try {
+    await expect(dialogContent).toHaveCSS('padding-top', '10px')
+    await expect(dialogContent).toHaveCSS('padding-right', '10px')
+    await expect(dialogContent).toHaveCSS('padding-bottom', '10px')
+    await expect(dialogContent).toHaveCSS('padding-left', '10px')
+  } finally {
+    await closeAbout(aboutApi)
+  }
+}


### PR DESCRIPTION
Adds an end-to-end regression test verifying the About dialog content has 10px padding on every side.