### PR TITLE
fix: use button for about dialog close

### DIFF
--- a/packages/about-view/src/parts/AriaRoles/AriaRoles.ts
+++ b/packages/about-view/src/parts/AriaRoles/AriaRoles.ts
@@ -1,2 +1,1 @@
-export const Button = 'button'
 export const Dialog = 'dialog'

--- a/packages/about-view/src/parts/GetDialogVirtualDom/GetDialogVirtualDom.ts
+++ b/packages/about-view/src/parts/GetDialogVirtualDom/GetDialogVirtualDom.ts
@@ -42,8 +42,7 @@ export const getDialogVirtualDom = (
       childCount: 1,
       className: ClassNames.DialogClose,
       onClick: DomEventListenerFunctions.HandleClickClose,
-      role: AriaRoles.Button,
-      type: VirtualDomElements.Div,
+      type: VirtualDomElements.Button,
     },
     {
       childCount: 0,

--- a/packages/about-view/test/GetAboutVirtualDom.test.ts
+++ b/packages/about-view/test/GetAboutVirtualDom.test.ts
@@ -49,8 +49,7 @@ test('formatDate - 1 millisecond ago', () => {
       childCount: 1,
       className: 'DialogClose',
       onClick: 1,
-      role: 'button',
-      type: 4,
+      type: 1,
     },
     {
       childCount: 0,

--- a/packages/e2e/src/about.accessibility.ts
+++ b/packages/e2e/src/about.accessibility.ts
@@ -8,11 +8,13 @@ export const test: Test = async ({ About, expect, Locator }) => {
   const dialogContent = await openAbout(aboutApi)
 
   try {
+    const closeButton = getCloseButton(dialogContent)
     await expect(getHeading(dialogContent)).toHaveId('DialogHeading')
     await expect(getInfoIcon(dialogContent)).toHaveId('DialogIcon')
     await expect(getInfoIcon(dialogContent)).toHaveAttribute('aria-label', 'Info')
-    await expect(getCloseButton(dialogContent)).toHaveAttribute('aria-label', 'Close Dialog')
-    await expect(getCloseButton(dialogContent)).toHaveAttribute('role', 'button')
+    await expect(closeButton).toHaveAttribute('aria-label', 'Close Dialog')
+    await expect(dialogContent.locator('button.DialogClose')).toHaveCount(1)
+    await expect(dialogContent.locator('.DialogClose[role]')).toHaveCount(0)
   } finally {
     await closeAbout(aboutApi)
   }


### PR DESCRIPTION
Summary:
- render the About dialog close control as a native button
- remove the redundant button role and cover the DOM semantics