### PR TITLE
feature: expand about accessibility e2e coverage

### DIFF
--- a/packages/e2e/src/about.action-button-accessibility.ts
+++ b/packages/e2e/src/about.action-button-accessibility.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { closeAbout, openAbout } from './_about.js'
+
+export const name = 'about.action-button-accessibility'
+
+export const test: Test = async ({ About, expect, Locator }) => {
+  const aboutApi = { About, expect, Locator }
+  const dialogContent = await openAbout(aboutApi)
+
+  try {
+    await expect(dialogContent.locator('button.Button')).toHaveCount(2)
+    await expect(dialogContent.locator('button.ButtonSecondary[name="Ok"]')).toHaveText('Ok')
+    await expect(dialogContent.locator('button.ButtonPrimary[name="Copy"]')).toHaveText('Copy')
+    await expect(dialogContent.locator('.Button:not(button)')).toHaveCount(0)
+  } finally {
+    await closeAbout(aboutApi)
+  }
+}

--- a/packages/e2e/src/about.close-icon-accessibility.ts
+++ b/packages/e2e/src/about.close-icon-accessibility.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { closeAbout, getCloseButton, openAbout } from './_about.js'
+
+export const name = 'about.close-icon-accessibility'
+
+export const test: Test = async ({ About, expect, Locator }) => {
+  const aboutApi = { About, expect, Locator }
+  const dialogContent = await openAbout(aboutApi)
+  const closeButton = getCloseButton(dialogContent)
+
+  try {
+    await expect(closeButton).toHaveAttribute('aria-label', 'Close Dialog')
+    await expect(closeButton.locator('.MaskIconClose')).toHaveCount(1)
+    await expect(dialogContent.locator('.MaskIconClose[aria-label]')).toHaveCount(0)
+    await expect(dialogContent.locator('.MaskIconClose[role]')).toHaveCount(0)
+  } finally {
+    await closeAbout(aboutApi)
+  }
+}


### PR DESCRIPTION
Add end-to-end coverage for native About dialog action controls and close-icon ARIA ownership. These checks guard accessible control semantics without overlapping the close-button implementation change.