### PR TITLE
feature: use dialog worker directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2956,9 +2956,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.20.0.tgz",
-      "integrity": "sha512-yDtT/MF73BsyMpx7DQSoJJLM3hJKTII9TuGEguwJmgULxqV3mND86npuvOhKGUjTvL0Fs8BEQYFjO4DCrjncwA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
+      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
@@ -15887,7 +15887,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.39.0",
+        "@lvce-editor/rpc-registry": "^9.42.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",
         "jest": "^30.4.2",
@@ -15895,14 +15895,14 @@
       }
     },
     "packages/about-view/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.39.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.39.0.tgz",
-      "integrity": "sha512-3ojIjE03w8thUcdKB7pbLxmN/V6/NHk2gaaiviUfoeRHI3e1cXVvX/fI1BG73/OXW9sU9KJehqkgepKtaNJU7g==",
+      "version": "9.42.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
+      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.20.0",
+        "@lvce-editor/constants": "^5.22.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },

--- a/packages/about-view/package.json
+++ b/packages/about-view/package.json
@@ -50,7 +50,7 @@
     "@lvce-editor/constants": "^5.20.0",
     "@lvce-editor/i18n": "^2.5.0",
     "@lvce-editor/rpc": "^6.10.0",
-    "@lvce-editor/rpc-registry": "^9.39.0",
+    "@lvce-editor/rpc-registry": "^9.42.0",
     "@lvce-editor/viewlet-registry": "^5.5.0",
     "@lvce-editor/virtual-dom-worker": "^11.8.1",
     "jest": "^30.4.2",

--- a/packages/about-view/src/parts/ElectronDialog/ElectronDialog.ts
+++ b/packages/about-view/src/parts/ElectronDialog/ElectronDialog.ts
@@ -1,4 +1,4 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker } from '@lvce-editor/rpc-registry'
 import * as GetWindowId from '../GetWindowId/GetWindowId.ts'
 
 export const showMessageBox = async (options: any): Promise<any> => {
@@ -7,5 +7,5 @@ export const showMessageBox = async (options: any): Promise<any> => {
     ...options,
     windowId,
   }
-  return RendererWorker.showMessageBox(finalOptions)
+  return DialogWorker.invoke('ElectronDialog.showMessageBox', finalOptions)
 }

--- a/packages/about-view/src/parts/Listen/Listen.ts
+++ b/packages/about-view/src/parts/Listen/Listen.ts
@@ -1,3 +1,5 @@
+import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import { registerCommands } from '../AboutStates/AboutStates.ts'
 import * as CommandMap from '../CommandMap/CommandMap.ts'
 import { initializeFileSystemWorker } from '../InitializeFileSystemWorker/InitializeFileSystemWorker.ts'
@@ -7,4 +9,9 @@ export const listen = async (): Promise<void> => {
   registerCommands(CommandMap.commandMap)
   await initializeRendererWorker()
   await initializeFileSystemWorker()
+  const dialogRpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send: RendererWorker.sendMessagePortToDialogWorker,
+  })
+  DialogWorker.set(dialogRpc)
 }

--- a/packages/about-view/test/ElectronDialog.test.ts
+++ b/packages/about-view/test/ElectronDialog.test.ts
@@ -1,14 +1,16 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ElectronDialog from '../src/parts/ElectronDialog/ElectronDialog.ts'
 
 test('showMessageBox - calls RendererWorker.invoke with correct arguments', async () => {
   const calls: { method: string; args: readonly any[] }[] = []
-  RendererWorker.registerMockRpc({
+  DialogWorker.registerMockRpc({
     'ElectronDialog.showMessageBox'(options: any): number {
       calls.push({ args: [options], method: 'ElectronDialog.showMessageBox' })
       return 1
     },
+  })
+  RendererWorker.registerMockRpc({
     'GetWindowId.getWindowId'(): number {
       calls.push({ args: [], method: 'GetWindowId.getWindowId' })
       return 1
@@ -28,10 +30,12 @@ test('showMessageBox - calls RendererWorker.invoke with correct arguments', asyn
 })
 
 test('showMessageBox - handles error from RendererWorker', async () => {
-  RendererWorker.registerMockRpc({
+  DialogWorker.registerMockRpc({
     'ElectronDialog.showMessageBox'(): never {
       throw new Error('Failed to show message box')
     },
+  })
+  RendererWorker.registerMockRpc({
     'GetWindowId.getWindowId'(): number {
       return 1
     },

--- a/packages/about-view/test/ShowAbout.test.ts
+++ b/packages/about-view/test/ShowAbout.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { FileSystemWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, FileSystemWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
 import * as ShowAbout from '../src/parts/ShowAbout/ShowAbout.ts'
 
@@ -22,10 +22,6 @@ test('showAbout - electron platform', async () => {
     },
   })
   RendererWorker.registerMockRpc({
-    'ElectronDialog.showMessageBox'(): number {
-      wasCalled = true
-      return 1
-    },
     'GetWindowId.getWindowId'(): number {
       return 1
     },
@@ -43,6 +39,12 @@ test('showAbout - electron platform', async () => {
     },
     'Process.getV8Version'(): string {
       return '10.0.0'
+    },
+  })
+  DialogWorker.registerMockRpc({
+    'ElectronDialog.showMessageBox'(): number {
+      wasCalled = true
+      return 1
     },
   })
   await ShowAbout.showAbout(PlatformType.Electron)

--- a/packages/about-view/test/ShowAboutElectron.test.ts
+++ b/packages/about-view/test/ShowAboutElectron.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { FileSystemWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, FileSystemWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ShowAboutElectron from '../src/parts/ShowAboutElectron/ShowAboutElectron.ts'
 
 const detail = 'Version: 1.2.3\nCommit: abc123\nDate: unknown\nElectron: x\nChromium: x\nNode: x\nV8: x'
@@ -18,12 +18,9 @@ const registerFileSystemMock = (): ReturnType<typeof FileSystemWorker.registerMo
   })
 }
 
-const registerRendererMock = (buttonIndex: number): ReturnType<typeof RendererWorker.registerMockRpc> => {
+const registerRendererMock = (): ReturnType<typeof RendererWorker.registerMockRpc> => {
   return RendererWorker.registerMockRpc({
     'ClipBoard.writeText'(_text: string): void {},
-    'ElectronDialog.showMessageBox'(_options: any): number {
-      return buttonIndex
-    },
     'GetWindowId.getWindowId'(): number {
       return 1
     },
@@ -45,6 +42,14 @@ const registerRendererMock = (buttonIndex: number): ReturnType<typeof RendererWo
   })
 }
 
+const registerDialogMock = (buttonIndex: number): ReturnType<typeof DialogWorker.registerMockRpc> => {
+  return DialogWorker.registerMockRpc({
+    'ElectronDialog.showMessageBox'(_options: any): number {
+      return buttonIndex
+    },
+  })
+}
+
 const expectedOptions = {
   buttons: ['Copy', 'Ok'],
   detail,
@@ -56,28 +61,27 @@ const expectedOptions = {
 
 test('showAboutElectron - clicks ok button', async () => {
   using mockFileRpc = registerFileSystemMock()
-  using mockRpc = registerRendererMock(1)
+  using mockRendererRpc = registerRendererMock()
+  using mockDialogRpc = registerDialogMock(1)
 
   await ShowAboutElectron.showAboutElectron()
 
-  expect(mockRpc.invocations.find((invocation: readonly any[]) => invocation[0] === 'ElectronDialog.showMessageBox')).toEqual([
-    'ElectronDialog.showMessageBox',
-    expectedOptions,
-  ])
+  expect(mockDialogRpc.invocations).toEqual([['ElectronDialog.showMessageBox', expectedOptions]])
   expect(mockFileRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
-  expect(mockRpc.invocations.some((invocation: readonly any[]) => invocation[0] === 'ClipBoard.writeText')).toBe(false)
+  expect(mockRendererRpc.invocations.some((invocation: readonly any[]) => invocation[0] === 'ClipBoard.writeText')).toBe(false)
 })
 
 test('showAboutElectron - clicks copy button', async () => {
   using mockFileRpc = registerFileSystemMock()
-  using mockRpc = registerRendererMock(0)
+  using mockRendererRpc = registerRendererMock()
+  using mockDialogRpc = registerDialogMock(0)
 
   await ShowAboutElectron.showAboutElectron()
 
-  expect(mockRpc.invocations.find((invocation: readonly any[]) => invocation[0] === 'ElectronDialog.showMessageBox')).toEqual([
-    'ElectronDialog.showMessageBox',
-    expectedOptions,
-  ])
+  expect(mockDialogRpc.invocations).toEqual([['ElectronDialog.showMessageBox', expectedOptions]])
   expect(mockFileRpc.invocations).toEqual([['FileSystem.readFile', 'config.json']])
-  expect(mockRpc.invocations.find((invocation: readonly any[]) => invocation[0] === 'ClipBoard.writeText')).toEqual(['ClipBoard.writeText', detail])
+  expect(mockRendererRpc.invocations.find((invocation: readonly any[]) => invocation[0] === 'ClipBoard.writeText')).toEqual([
+    'ClipBoard.writeText',
+    detail,
+  ])
 })


### PR DESCRIPTION
## Summary

- connect to dialog-worker through a lazy transferred message port
- send confirm and message-box requests directly to dialog-worker
- update rpc-registry and the affected tests

## Testing

- focused dialog and Listen tests
- npm run type-check
- npm run lint