### PR TITLE
fix: correct dev build watch paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "node packages/build/src/build.ts",
     "build:static": "node packages/build/src/build-static.ts",
-    "build:watch": "npm exec --workspace=packages/build -- esbuild --format=esm --bundle --external:node:buffer --external:electron --external:ws --external:node:worker_threads --bundle --watch packages/about-view/src/aboutWorkerMain.ts --outfile=.tmp/dist/dist/aboutWorkerMain.js",
+    "build:watch": "npm exec --workspace=packages/build -- esbuild --format=esm --bundle --external:node:buffer --external:electron --external:ws --external:node:worker_threads --bundle --watch ../about-view/src/aboutWorkerMain.ts --outfile=../../.tmp/dist/dist/aboutWorkerMain.js",
     "dev": "node packages/build/src/dev.ts",
     "e2e": "npm run e2e --workspace=packages/e2e",
     "e2e:firefox": "npm run e2e:firefox --workspace=packages/e2e",


### PR DESCRIPTION
Fix the about-view development watcher paths so they resolve from the build workspace.

The dev server now emits the about worker bundle at the repository-level temporary output path.