### PR TITLE
Update LVCE Editor server to 0.96.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2764,6 +2764,7 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.14.0.tgz",
       "integrity": "sha512-iryFo2ewCtq4l4j1TZN3FAAjYDROu3fg/pOLA2gID9Sbbjwoaedj/Q3lxTQ/yBmGOtjo0ykVLKCyZjqGBSvPXA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -2901,6 +2902,7 @@
       "version": "0.95.7",
       "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.95.7.tgz",
       "integrity": "sha512-X3xIujlKUR9+lKNn5lAwszyyMRYTcSZqsAauTQ0oedn/5hhnTAgqhzLFH7iuzUu3h7d09w3mJNwEj/U4j7mL1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -2916,6 +2918,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.7.0.tgz",
       "integrity": "sha512-tA0GKQ1xwl38YivgPLbCfaYQ/D+EUzL9xn2sOp0yc9imIz6Tf49acI0jLD0/iAodbqeBX6EzjSWRXqXnpa4ygg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2933,6 +2936,7 @@
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.9.0.tgz",
       "integrity": "sha512-bAJwrxnjiLL2Wb/saGDyVg1Rh+fDpBBuFqzTCOkMu4X8J8EZZ+rE1D2/K59lSL868wgsUSMNBE8AWzGLawkUsQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2957,6 +2961,7 @@
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.6.0.tgz",
       "integrity": "sha512-DYP2n651sgxPq6ovBDsuKFo+SnuS6/ipEH64DZGFaBjNJ+PFUrUHq+5gZiUgBM9GifGkyTKFSGL7eq4K5/EETg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3205,6 +3210,7 @@
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.1.tgz",
       "integrity": "sha512-C5K/24ThaIoYRq30hBk0jXAtVwQzY2tWNdcbUW72mKNww+EmGhXlHlHA6Cwhz7ae8Q4Dfd9XeekKMBVlNWweTA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "process-explorer": "bin/processExplorer.js"
@@ -3220,6 +3226,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.4.0.tgz",
       "integrity": "sha512-Ka/MkHduJi6N/42FQuA+Qiz41HzmRnuXiyABZTENQi9/HE/Z+PrXQ92RDpSh9El4lrLX0JNMvhnk2EqgqcJw/Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3243,14 +3250,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.14.0.tgz",
-      "integrity": "sha512-6B86mcoXEZQ1EN/HbQ29n0woY08uMQnaGde0ugComuFKA4g3eqYhF/unwyw2Ggw8kEFRslYkFN77W2LA2MrjCw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
+      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.7.0",
+        "@lvce-editor/ipc": "^16.9.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
@@ -3259,6 +3266,7 @@
       "version": "9.43.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.43.0.tgz",
       "integrity": "sha512-STUNoKvOO9D90p2sk3PXJKwVwEGwArBPB33pCImfBg6HrTP2Q/OPZMzi4HXwseNfusOO6xPlaiXKEND1fgwlOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3285,6 +3293,7 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.3.0.tgz",
       "integrity": "sha512-HakFxJ2h7rWTFFvD/pEcPE1EPvikQpLooxxYkmqt5YhtWl24xikJGrwl/uGVfrsrqp8o1kEZ6DPVY9nvKRjFRw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3306,6 +3315,7 @@
       "version": "0.95.7",
       "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.95.7.tgz",
       "integrity": "sha512-rmPk8Tl92tsEFVCrwKumUBsNRU+6lrO6vBur3pZxA2mmPY3rC5l67AcdHHN5AyP60X1kJOlbPjm8oUXQF5dBPA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/shared-process": "0.95.7",
@@ -3322,6 +3332,7 @@
       "version": "0.95.7",
       "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.95.7.tgz",
       "integrity": "sha512-ZMpCLDQtBk6GF6I0//5IbSU8fHms6yBcoRcPcyQgC/NaA1zaF8hg+iyWwiPwr+xwQgfM37RmfBVVkg0AXWOrfw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
@@ -3360,6 +3371,7 @@
       "version": "0.95.7",
       "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.95.7.tgz",
       "integrity": "sha512-0AANhuk21P5XlzevteyJwl5hG02vR6EPc68x5blXPqKm55JQPeXpgMY4QfVr/2u39n99dzmByZFk8byEaHk8iA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -3412,6 +3424,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.6.0.tgz",
       "integrity": "sha512-sYPqS7waW8Abz8Itum8voW6kalbv4XiVqEtSzw+ABLHLsU7tvbt/Mvru/lf9rUYLrdSTYMCTuYk6CvfBcUPKVg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -6018,6 +6031,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -7278,6 +7292,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -10197,6 +10212,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
       "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10341,6 +10357,7 @@
       "version": "14.3.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
       "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13445,6 +13462,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uglify-js": {
@@ -14210,10 +14228,237 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.95.7"
+        "@lvce-editor/server": "0.96.12"
       },
       "devDependencies": {
         "@types/node": "^26.0.1"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/assert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
+      "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
+      "license": "MIT"
+    },
+    "packages/server/node_modules/@lvce-editor/embeds-process": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
+      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "embeds-process": "bin/embedsProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/extension-host-helper-process": {
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.12.tgz",
+      "integrity": "sha512-ERncFru8iwPAn8xHjHYBXnyOlDL5RU4uUbKFqCkvhfCG8v2Anmz1ilPK25kQxKXUAdTY7hzX5yylgeCACzH5DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/verror": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/file-system-process": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
+      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "trash": "^10.1.1",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "file-system-process": "bin/fileSystemProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/file-watcher-process": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
+      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "chokidar": "^5.0.0"
+      },
+      "bin": {
+        "file-watcher-process": "bin/fileWatcherProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/ipc": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/json-rpc": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
+      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
+      "license": "MIT"
+    },
+    "packages/server/node_modules/@lvce-editor/process-explorer": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
+      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/pty-host": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
+      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0"
+      },
+      "bin": {
+        "pty-host": "bin/ptyHost.js"
+      },
+      "optionalDependencies": {
+        "node-pty": "1.1.0-beta34"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.47.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.47.0.tgz",
+      "integrity": "sha512-EmtSPKK3XMt49CeyzLdSv+Ey4umTRIOOS64Inn/mJxCcmRe+bUi4+ik98PAf9Z+AfLiEV3d/Yjgs2IvBzvKJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.25.0",
+        "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/search-process": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
+      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "execa": "^9.6.1",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "search-process": "bin/searchProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/ripgrep": "^5.2.0"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/server": {
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.12.tgz",
+      "integrity": "sha512-XHvSr501fv/0MIbJXSzIMrLDq4djzRaLlHewKMlGtr57/Btz/atqVeb5g8wbsLS+HLdd9hQOVZM1LrGEvaHiRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/shared-process": "0.96.12",
+        "@lvce-editor/static-server": "0.96.12"
+      },
+      "bin": {
+        "server": "bin/server.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/shared-process": {
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.12.tgz",
+      "integrity": "sha512-ZdyOoNfEaHYPPEYDSuoKuMr9waXTzLwrAHxKj/sC27L9oLzP/CL2HW7iQosJRorTwTtfpm9l/k3y7KYrR8M6Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.96.12",
+        "@lvce-editor/ipc": "16.10.0",
+        "@lvce-editor/json-rpc": "8.6.0",
+        "@lvce-editor/jsonc-parser": "1.5.0",
+        "@lvce-editor/pretty-error": "2.0.0",
+        "@lvce-editor/process-explorer": "3.14.0",
+        "@lvce-editor/rpc-registry": "9.47.0",
+        "@lvce-editor/verror": "1.7.0",
+        "is-object": "^1.0.2",
+        "markdown-it": "^15.0.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/embeds-process": "4.15.0",
+        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-watcher-process": "4.12.0",
+        "@lvce-editor/network-process": "5.2.0",
+        "@lvce-editor/preload": "1.5.0",
+        "@lvce-editor/preview-process": "11.0.0",
+        "@lvce-editor/pty-host": "8.7.0",
+        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/typescript-compile-process": "5.8.0",
+        "open": "^11.0.0",
+        "tail": "^2.2.6",
+        "tmp-promise": "^3.0.3",
+        "trash": "^10.1.1"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/static-server": {
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.12.tgz",
+      "integrity": "sha512-9hMcQbGGTJYknInPdjetwMT9lUe2n/nyAfoPM0rylzh9h1Is7FcQXdot+XQKz8Zx45j344niQC+z+O1nCZfwnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/typescript-compile-process": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
+      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "typescript-compile-process": "bin/typescriptCompileProcess.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/server/node_modules/@types/node": {
@@ -14225,6 +14470,86 @@
       "dependencies": {
         "undici-types": "~8.3.0"
       }
+    },
+    "packages/server/node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
+    },
+    "packages/server/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "packages/server/node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
+    "packages/server/node_modules/markdown-it": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "packages/server/node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "license": "MIT"
     },
     "packages/server/node_modules/undici-types": {
       "version": "8.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "0.95.7"
+    "@lvce-editor/server": "0.96.12"
   },
   "devDependencies": {
     "@types/node": "^26.0.1"


### PR DESCRIPTION
Updates `@lvce-editor/server` to the frozen latest published version for this rollout.