### PR TITLE
Update ESLint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^18.2.0",
+        "@lvce-editor/eslint-config": "^18.4.0",
         "@lvce-editor/server": "0.99.18",
         "eslint": "^10.8.1",
         "knip": "^6.32.0",
@@ -2774,9 +2774,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.2.0.tgz",
-      "integrity": "sha512-depjU3Z65NieU9IHl3xNUZIrP1Xt1AwQf6n9CEQxefGFttsx6XoW/CQ2BaBRD5ROTsYiSVXM9kaJF4g24TuX2Q==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.4.0.tgz",
+      "integrity": "sha512-Hni5Ub2jqyAQ3FgsGS3gk6PT/jKF5mS6oFZrqgDjJTcBf5nlZGg8WjEwpcyVUagVcrQPqrcJprEbImVvFUohFQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2788,16 +2788,16 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "18.2.0",
-        "@lvce-editor/eslint-plugin-e2e": "18.2.0",
-        "@lvce-editor/eslint-plugin-eslint-config": "18.2.0",
-        "@lvce-editor/eslint-plugin-extension-json": "18.2.0",
-        "@lvce-editor/eslint-plugin-github-actions": "18.2.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "18.2.0",
-        "@lvce-editor/eslint-plugin-regex": "18.2.0",
-        "@lvce-editor/eslint-plugin-rpc": "18.2.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "18.2.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "18.2.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "18.4.0",
+        "@lvce-editor/eslint-plugin-e2e": "18.4.0",
+        "@lvce-editor/eslint-plugin-eslint-config": "18.4.0",
+        "@lvce-editor/eslint-plugin-extension-json": "18.4.0",
+        "@lvce-editor/eslint-plugin-github-actions": "18.4.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "18.4.0",
+        "@lvce-editor/eslint-plugin-regex": "18.4.0",
+        "@lvce-editor/eslint-plugin-rpc": "18.4.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "18.4.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "18.4.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2812,9 +2812,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.2.0.tgz",
-      "integrity": "sha512-oGP5M6eRRNsxBNdeEWJHdB2lUU7MBlUKkSO9laZhdw8sz52cCTldh75IN3+Xj/WUN7tkHgN+RybfxjhfLzOg9g==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.4.0.tgz",
+      "integrity": "sha512-+iItlCPV5Xj3c0q5iCZZR9nZeiFYNw/InwMYEj2CfHDi4XmJ+TSInMFyQSK6+GDMezD1okly7CDHyzM2YCpE9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2822,23 +2822,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.2.0.tgz",
-      "integrity": "sha512-AIpv+tOAMqH+rBK/Mx7P7pzKpF3YnS3xCZJBoHxx4VdWBSMrhTNQJvkXdhIZIgu9uGKU6FbBTq+o9FBk1jTfhw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.4.0.tgz",
+      "integrity": "sha512-lg75DLSSrn9vt2p1OGkettK5CEOOZU+26hBEIaU1HKv5q8PgaM+jIhPF/g4KutMgq0F0qjXcika4tlPbQBFRGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-eslint-config": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.2.0.tgz",
-      "integrity": "sha512-yVwr5EunNy7lh4sCaeu6y0/jYpMTqgP/S7lZOMz4OUn26skMxF+weRFjIKiADvx2FC65YkrWDx7eC0fRtk3AEA==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.4.0.tgz",
+      "integrity": "sha512-BW+7W4Gecp2CenHuVy5VRggIHjJ6vVhkJpL59XYRIf5TqFznEhVDW6iIipePL2kGtu/JnXh6162QE3rEpsJ7qg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-extension-json": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.2.0.tgz",
-      "integrity": "sha512-Z6A3jwLDvUsDaP2AMZ80QCr7xGVCsJY5MPj4K5hMR6BeXm2nBqv4bp+NFFFFh9fcvzhh3Lf1Uq+r/uwAsL8p5A==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.4.0.tgz",
+      "integrity": "sha512-jd86DG62e/DLvMWMh03byuBj/k9kOeWXRUSSuGTb9be0TsjKdKbeP8hDUFBrLD8osaNUMr5tfDsNZE19gDjA2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2846,9 +2846,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.2.0.tgz",
-      "integrity": "sha512-jzC9qzB6wl7lQREaiW1EWWIp8G+eOF6M71R3Xj6qGAbGhAbDvb/MOEHQsLZW/DBUTtDyskC7LU9UvxmxPE2H1g==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.4.0.tgz",
+      "integrity": "sha512-HAkU0VXCXqiRSpKdGxjkHDBrV7w38uVtF4iOwpELffx6Olt97aJLz5/6nTZvJShv+BcdEgnvH1nnog0FN79tlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2857,9 +2857,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.2.0.tgz",
-      "integrity": "sha512-fybjUNLG3Jk+4dHn9Jyj94EzFMN8f1HP0avE2o8IIGFbR5B3lBw49Hz9aRQEZMy8l4vbk3OtKC9h3q6t1sQ38w==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.4.0.tgz",
+      "integrity": "sha512-wiv8PY1qn95Sxhy2PoplK9ZplEtjqSQWEzTWfWg3OkR5Kay8w1zf3JiTX86mhT4ic6BQ+A7d5hxgJ+T6H5EKuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2867,23 +2867,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.2.0.tgz",
-      "integrity": "sha512-Cm++lkCreG53R73iocNfXLOa/uVLjKRDugQBWV4sy2XVgyZvsZWeCKZWBfMsN+LP3MRVj2p0Fzlbi5ywHI47YQ==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.4.0.tgz",
+      "integrity": "sha512-7A6AiK56pWt6s3eYkdC2heynXfKGAfOGsi7/xgT/Pvb91SJN5VheIl3WMGt2hcDWrsd5dUJfq5BWk7ZieSYyzw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.2.0.tgz",
-      "integrity": "sha512-mPhh+IAk7NnlcuSfFLDclypKlY0PwBjJNc3hPn2Wma24Ww3kHwlU+p1SlvU/jU5T12kBcqb60djIseBL03xBnw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.4.0.tgz",
+      "integrity": "sha512-NkXd4SXwaKJHUfz0z7i+wrDXxcp9xZaPTuOs/Eyr8nMvdw7q6lU+B+wEZNuu0sM3l3uboiKhVbRIIlFN51InEg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.2.0.tgz",
-      "integrity": "sha512-nj9Rsrdbpdzqd4WrvGYWFCKOSALn/iqPrSHeyyQqpUf2+ZzsZxmy2pnnbCGuNozZ3BRr8AazwliygPcYflJIcw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.4.0.tgz",
+      "integrity": "sha512-DgMtmiEr1t65qoObuq8vptXOx/Ucyk3aeJFoZdr9Ze8gwN0hUdFMyCZmNmVqN+tW06HJ+Drc2F1Ts8+SfCWOiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2891,9 +2891,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.2.0.tgz",
-      "integrity": "sha512-bFPELVF4H7uSUDS7gQ4v2naq8gfJ+aTA0upxCkVxPkbrl2j+7sZP6aTtL6Tl+i90VnEZ57sJeJUu0DXjETDt5Q==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.4.0.tgz",
+      "integrity": "sha512-DZ7gFfc06T2Ysf12vW3M6pGUzOQtxgSwdhkTasSqzvuxFKqN1vBw5koOzhPL5QjhMlLFY9u/ncMWq5CX+3s/8g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^18.2.0",
+    "@lvce-editor/eslint-config": "^18.4.0",
     "@lvce-editor/server": "0.99.18",
     "eslint": "^10.8.1",
     "knip": "^6.32.0",

--- a/packages/e2e/src/about.click-copy.ts
+++ b/packages/e2e/src/about.click-copy.ts
@@ -10,15 +10,11 @@ export const test: Test = async ({ About, ClipBoard, expect, Locator }) => {
   const dialogContent = await openAbout(aboutApi)
   await ClipBoard.enableMemoryClipBoard()
 
-  try {
-    // act
-    // eslint-disable-next-line e2e/no-direct-click -- verifies the rendered Copy button invokes the clipboard action
-    await getCopyButton(dialogContent).click()
+  // act
+  // eslint-disable-next-line e2e/no-direct-click -- verifies the rendered Copy button invokes the clipboard action
+  await getCopyButton(dialogContent).click()
 
-    // assert
-    await waitForHidden(expect, dialogContent)
-    await ClipBoard.shouldHaveText(/Version: [^\n]*\nCommit: [^\n]*\nDate: [^\n]*\nBrowser: /)
-  } finally {
-    await ClipBoard.disableMemoryClipBoard()
-  }
+  // assert
+  await waitForHidden(expect, dialogContent)
+  await ClipBoard.shouldHaveText(/Version: [^\n]*\nCommit: [^\n]*\nDate: [^\n]*\nBrowser: /)
 }

--- a/packages/e2e/src/about.reopen-after-copy.ts
+++ b/packages/e2e/src/about.reopen-after-copy.ts
@@ -8,17 +8,13 @@ export const test: Test = async ({ About, ClipBoard, expect, Locator }) => {
   const firstDialogContent = await openAbout(aboutApi)
   await ClipBoard.enableMemoryClipBoard()
 
-  try {
-    await About.handleClickCopy()
-    await expect(firstDialogContent).toBeHidden()
+  await About.handleClickCopy()
+  await expect(firstDialogContent).toBeHidden()
 
-    const secondDialogContent = await openAbout(aboutApi)
-    try {
-      await waitForFocused(expect, getOkButton(secondDialogContent))
-    } finally {
-      await closeAbout(aboutApi)
-    }
+  const secondDialogContent = await openAbout(aboutApi)
+  try {
+    await waitForFocused(expect, getOkButton(secondDialogContent))
   } finally {
-    await ClipBoard.disableMemoryClipBoard()
+    await closeAbout(aboutApi)
   }
 }


### PR DESCRIPTION
Updates ESLint and the LVCE Editor ESLint config to their latest versions.

Removes obsolete manual memory-clipboard teardown from two e2e tests; the test harness now performs that cleanup automatically.