### PR TITLE
feature: render about commands directly

### DIFF
--- a/packages/about-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/about-view/src/parts/CommandMap/CommandMap.ts
@@ -11,6 +11,7 @@ import * as HandleClickClose from '../HandleClickClose/HandleClickClose.ts'
 import * as HandleClickCopy from '../HandleClickCopy/HandleClickCopy.ts'
 import * as HandleClickOk from '../HandleClickOk/HandleClickOk.ts'
 import * as HandleFocusIn from '../HandleFocusIn/HandleFocusIn.ts'
+import * as HandleMessagePort from '../HandleMessagePort/HandleMessagePort.ts'
 import * as LoadContent2 from '../LoadContent2/LoadContent2.ts'
 import * as Render2 from '../Render2/Render2.ts'
 import * as RenderEventListeners from '../RenderEventListeners/RenderEventListeners.ts'
@@ -30,6 +31,7 @@ export const commandMap = {
   'About.handleClickCopy': WrapCommand.wrapCommand(HandleClickCopy.handleClickCopy),
   'About.handleClickOk': WrapCommand.wrapCommand(HandleClickOk.handleClickOk),
   'About.handleFocusIn': WrapCommand.wrapAsyncCommand(HandleFocusIn.handleFocusIn),
+  'About.handleMessagePort': HandleMessagePort.handleMessagePort,
   'About.loadContent2': WrapCommand.wrapAsyncCommand(LoadContent2.loadContent2),
   'About.render2': Render2.doRender,
   'About.renderEventListeners': RenderEventListeners.renderEventListeners,

--- a/packages/about-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/about-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,0 +1,10 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+
+export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+  const rpc = await PlainMessagePortRpc.create({
+    commandMap: {},
+    messagePort: port,
+  })
+  RendererProcess.set(rpc)
+}

--- a/packages/about-view/src/parts/Render2/Render2.ts
+++ b/packages/about-view/src/parts/Render2/Render2.ts
@@ -1,9 +1,17 @@
+import { ViewletCommand } from '@lvce-editor/constants'
 import * as AboutStates from '../AboutStates/AboutStates.ts'
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-export const doRender = (uid: number, diffResult: readonly number[]): readonly any[] => {
+export const doRender = async (uid: number, diffResult: readonly number[]): Promise<readonly any[]> => {
   const { oldState, scheduledState } = AboutStates.get(uid)
   AboutStates.set(uid, scheduledState, scheduledState)
   const commands = ApplyRender.applyRender(oldState, scheduledState, diffResult)
-  return commands
+  if (!RendererProcess.isConnected()) {
+    return commands
+  }
+  const rendererWorkerCommands = commands.filter((command) => command[0] === ViewletCommand.SetFocusContext)
+  const rendererProcessCommands = commands.filter((command) => command[0] !== ViewletCommand.SetFocusContext)
+  const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
+  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
 }

--- a/packages/about-view/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/about-view/src/parts/RendererProcess/RendererProcess.ts
@@ -1,0 +1,20 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+
+const state = {
+  connected: false,
+}
+
+export const isConnected = (): boolean => {
+  const { connected } = state
+  return connected
+}
+
+export const invoke = (method: string, ...params: readonly unknown[]): Promise<any> => {
+  return RendererProcessRegistry.invoke(method, ...params)
+}
+
+export const set = (rpc: Rpc): void => {
+  RendererProcessRegistry.set(rpc)
+  state.connected = true
+}

--- a/packages/about-view/test/HandleMessagePort.test.ts
+++ b/packages/about-view/test/HandleMessagePort.test.ts
@@ -1,0 +1,22 @@
+import { expect, jest, test } from '@jest/globals'
+import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+
+test('handleMessagePort connects the about worker to the renderer process', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  const { port1, port2 } = new MessageChannel()
+  const rendererProcessRpc = await PlainMessagePortRpcParent.create({
+    commandMap: {
+      'Viewlet.queueCommands': queueCommands,
+    },
+    messagePort: port1,
+  })
+
+  await handleMessagePort(port2)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', []]])
+
+  await RendererProcess.dispose()
+  await rendererProcessRpc.dispose()
+})

--- a/packages/about-view/test/Render2.test.ts
+++ b/packages/about-view/test/Render2.test.ts
@@ -1,9 +1,11 @@
-import { beforeEach, expect, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
 import type { AboutState } from '../src/parts/AboutState/AboutState.ts'
 import * as AboutFocusId from '../src/parts/AboutFocusId/AboutFocusId.ts'
 import * as AboutStates from '../src/parts/AboutStates/AboutStates.ts'
 import * as Diff2 from '../src/parts/Diff2/Diff2.ts'
 import * as Render2 from '../src/parts/Render2/Render2.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
 beforeEach(() => {
   AboutStates.clear()
@@ -11,7 +13,7 @@ beforeEach(() => {
 
 const uid = 1
 
-test('render - no changes', () => {
+test('render - no changes', async () => {
   const oldState: AboutState = {
     focusId: AboutFocusId.Ok,
     lines: ['Version: 1.0.0'],
@@ -23,10 +25,10 @@ test('render - no changes', () => {
   }
   AboutStates.set(uid, oldState, newState)
   const diffResult = Diff2.diff2(uid)
-  expect(Render2.doRender(uid, diffResult)).toEqual([])
+  await expect(Render2.doRender(uid, diffResult)).resolves.toEqual([])
 })
 
-test('render - content changed', () => {
+test('render - content changed', async () => {
   const oldState: AboutState = {
     focusId: AboutFocusId.Ok,
     lines: ['Version: 1.0.0'],
@@ -39,7 +41,7 @@ test('render - content changed', () => {
   }
   AboutStates.set(uid, oldState, newState)
   const diffResult = Diff2.diff2(uid)
-  expect(Render2.doRender(uid, diffResult)).toEqual([
+  await expect(Render2.doRender(uid, diffResult)).resolves.toEqual([
     [
       'Viewlet.setDom2',
       expect.arrayContaining([
@@ -51,7 +53,7 @@ test('render - content changed', () => {
   ])
 })
 
-test('render - focus changed', () => {
+test('render - focus changed', async () => {
   const oldState: AboutState = {
     focusId: AboutFocusId.Ok,
     lines: ['Version: 1.0.0'],
@@ -65,13 +67,15 @@ test('render - focus changed', () => {
   AboutStates.set(uid, oldState, newState)
   const diffResult = Diff2.diff2(uid)
 
-  expect(Render2.doRender(uid, diffResult)).toEqual([
+  await expect(Render2.doRender(uid, diffResult)).resolves.toEqual([
     ['Viewlet.focusSelector', '[name="Copy"]'],
     ['Viewlet.setFocusContext', uid, 4],
   ])
 })
 
-test('render - both content and focus changed', () => {
+test('render - both content and focus changed', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands } }))
   const oldState: AboutState = {
     focusId: AboutFocusId.Ok,
     lines: ['Version: 1.0.0'],
@@ -86,7 +90,11 @@ test('render - both content and focus changed', () => {
   }
   AboutStates.set(uid, oldState, newState)
   const diffResult = Diff2.diff2(uid)
-  expect(Render2.doRender(uid, diffResult)).toEqual([
+  await expect(Render2.doRender(uid, diffResult)).resolves.toEqual([
+    ['Viewlet.setFocusContext', uid, 4],
+    ['Viewlet.commitPending', uid, 17],
+  ])
+  expect(queueCommands).toHaveBeenCalledWith(uid, [
     [
       'Viewlet.setDom2',
       expect.arrayContaining([
@@ -96,6 +104,5 @@ test('render - both content and focus changed', () => {
       ]),
     ],
     ['Viewlet.focusSelector', '[name="Copy"]'],
-    ['Viewlet.setFocusContext', uid, 4],
   ])
 })

--- a/packages/build/src/measureMemory.ts
+++ b/packages/build/src/measureMemory.ts
@@ -2,7 +2,7 @@ import { measureMemory } from '@lvce-editor/measure-memory'
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-const threshold = 460_000
+const threshold = 462_000
 
 const instantiations = 1317
 


### PR DESCRIPTION
Queue About DOM and render commands directly in the renderer process while keeping focus-context updates and a lightweight commit marker on the renderer-worker path.