### PR TITLE
build: package notification center worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.4.0",
+        "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.1/lvce-editor-notification-center-view-0.1.1.tgz",
         "@lvce-editor/server": "0.100.17",
         "eslint": "^10.8.1",
         "knip": "^6.32.2",
@@ -3165,6 +3166,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@lvce-editor/notification-center-view": {
+      "version": "0.1.1",
+      "resolved": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.1/lvce-editor-notification-center-view-0.1.1.tgz",
+      "integrity": "sha512-BqfQx8nA7CnFV8iFJ5ohm8mrBmbMQ9ZeJZ1SIo72rHeWUWSR2EaPuclf5YUybm86rl40ZQxf9netAyEZNT6iXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lvce-editor/preload": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.4.0",
+    "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.1/lvce-editor-notification-center-view-0.1.1.tgz",
     "@lvce-editor/server": "0.100.17",
     "eslint": "^10.8.1",
     "knip": "^6.32.2",

--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -1,6 +1,7 @@
 import { execa } from 'execa'
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { bundleJs } from './bundleJs.ts'
 import { root } from './root.ts'
 
@@ -53,6 +54,8 @@ await rm(dist, { recursive: true, force: true })
 await mkdir(dist, { recursive: true })
 
 await bundleJs()
+
+await cp(fileURLToPath(import.meta.resolve('@lvce-editor/notification-center-view')), join(dist, 'dist', 'notificationCenterWorkerMain.js'))
 
 const version = await getVersion()
 


### PR DESCRIPTION
## Summary

- include the dedicated notification-center worker in the published about-view artifact
- resolve the worker package through Node module resolution so the copy works with supported install layouts

## Validation

- npm run build
- npm test
- npm run type-check
- npm run lint
- git diff --check