### PR TITLE
fix: update notification center worker to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.4.0",
-        "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.1/lvce-editor-notification-center-view-0.1.1.tgz",
+        "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.2/lvce-editor-notification-center-view-0.1.2.tgz",
         "@lvce-editor/server": "0.100.17",
         "eslint": "^10.8.1",
         "knip": "^6.32.2",
@@ -3168,9 +3168,9 @@
       }
     },
     "node_modules/@lvce-editor/notification-center-view": {
-      "version": "0.1.1",
-      "resolved": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.1/lvce-editor-notification-center-view-0.1.1.tgz",
-      "integrity": "sha512-BqfQx8nA7CnFV8iFJ5ohm8mrBmbMQ9ZeJZ1SIo72rHeWUWSR2EaPuclf5YUybm86rl40ZQxf9netAyEZNT6iXQ==",
+      "version": "0.1.2",
+      "resolved": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.2/lvce-editor-notification-center-view-0.1.2.tgz",
+      "integrity": "sha512-6gmkjxpiICagTDhBRcd2fGmyHU814ZnKuIWcnFYIdv6FkVYTGoJiYlPt6+9tqOwR/ZfRFCzSDeGXtyibOXoRKw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.4.0",
-    "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.1/lvce-editor-notification-center-view-0.1.1.tgz",
+    "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.2/lvce-editor-notification-center-view-0.1.2.tgz",
     "@lvce-editor/server": "0.100.17",
     "eslint": "^10.8.1",
     "knip": "^6.32.2",


### PR DESCRIPTION
## Summary

- package notification-center-view v0.1.2
- include live notification updates for open center instances

## Validation

- npm run build
- packaged worker assertion
- npm run type-check
- npm run lint
- git diff --check