### PR TITLE
fix: restore about renderer command ids

### DIFF
--- a/packages/about-view/src/parts/RenderDialog/RenderDialog.ts
+++ b/packages/about-view/src/parts/RenderDialog/RenderDialog.ts
@@ -5,5 +5,5 @@ import * as GetAboutVirtualDom from '../GetAboutVirtualDom/GetAboutVirtualDom.ts
 export const renderDialog = (oldState: AboutState, newState: AboutState): readonly any[] => {
   const { closeMessage, copyMessage, infoMessage, lines, okMessage, productName } = CreateViewModel.createViewModel(newState)
   const dom = GetAboutVirtualDom.getAboutVirtualDom(productName, lines, closeMessage, okMessage, copyMessage, infoMessage)
-  return ['Viewlet.setDom2', dom]
+  return ['Viewlet.setDom2', newState.uid, dom]
 }

--- a/packages/about-view/src/parts/RenderFocus/RenderFocus.ts
+++ b/packages/about-view/src/parts/RenderFocus/RenderFocus.ts
@@ -3,5 +3,5 @@ import * as GetFocusSelector from '../GetFocusSelector/GetFocusSelector.ts'
 
 export const renderFocus = (oldState: AboutState, newState: AboutState): readonly any[] => {
   const name = GetFocusSelector.getFocusSelector(newState.focusId)
-  return ['Viewlet.focusSelector', `[name="${name}"]`]
+  return ['Viewlet.focusSelector', newState.uid, `[name="${name}"]`]
 }

--- a/packages/about-view/test/Render2.test.ts
+++ b/packages/about-view/test/Render2.test.ts
@@ -44,6 +44,7 @@ test('render - content changed', async () => {
   await expect(Render2.doRender(uid, diffResult)).resolves.toEqual([
     [
       'Viewlet.setDom2',
+      uid,
       expect.arrayContaining([
         expect.objectContaining({
           className: 'Viewlet About',
@@ -68,7 +69,7 @@ test('render - focus changed', async () => {
   const diffResult = Diff2.diff2(uid)
 
   await expect(Render2.doRender(uid, diffResult)).resolves.toEqual([
-    ['Viewlet.focusSelector', '[name="Copy"]'],
+    ['Viewlet.focusSelector', uid, '[name="Copy"]'],
     ['Viewlet.setFocusContext', uid, 4],
   ])
 })
@@ -97,12 +98,13 @@ test('render - both content and focus changed', async () => {
   expect(queueCommands).toHaveBeenCalledWith(uid, [
     [
       'Viewlet.setDom2',
+      uid,
       expect.arrayContaining([
         expect.objectContaining({
           className: 'Viewlet About',
         }),
       ]),
     ],
-    ['Viewlet.focusSelector', '[name="Copy"]'],
+    ['Viewlet.focusSelector', uid, '[name="Copy"]'],
   ])
 })


### PR DESCRIPTION
## Summary

- include the About viewlet uid in direct DOM render commands
- include the uid in direct focus-selector commands
- assert the exact direct renderer-process command shapes

## Root cause

The renderer-worker path used `AdjustCommands` to prepend the viewlet uid. Direct renderer-process dispatch bypasses that adjustment, shifting the arguments for `setDom2` and `focusSelector`, so the About view did not render.

## Verification

- `npm test` (50 suites, 168 tests)
- `npm run type-check`
- `npm run lint`
- `npm run build`