### PR TITLE
fix: update notification center worker to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.4.0",
-        "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.4/lvce-editor-notification-center-view-0.1.4.tgz",
+        "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.5/lvce-editor-notification-center-view-0.1.5.tgz",
         "@lvce-editor/server": "0.100.17",
         "eslint": "^10.8.1",
         "knip": "^6.32.2",
@@ -3168,9 +3168,9 @@
       }
     },
     "node_modules/@lvce-editor/notification-center-view": {
-      "version": "0.1.4",
-      "resolved": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.4/lvce-editor-notification-center-view-0.1.4.tgz",
-      "integrity": "sha512-MgK3Lqw55HDxXJg3Z02kO20a3fc3sV9NK1vjCiGu8PmEtt0H78eoEOxRt9KmhpfUJ6pvDMmsiHmXbXQZeGIrvg==",
+      "version": "0.1.5",
+      "resolved": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.5/lvce-editor-notification-center-view-0.1.5.tgz",
+      "integrity": "sha512-OlQ6bOVQ8AoFSrF5Ma462TILOCYD513wIFwUVzAX8X3Vs0BI66RmxExE14UMheVK3ooScSq5xY6XP7b4vDMAOg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.4.0",
-    "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.4/lvce-editor-notification-center-view-0.1.4.tgz",
+    "@lvce-editor/notification-center-view": "https://github.com/lvce-editor/notification-center-view/releases/download/v0.1.5/lvce-editor-notification-center-view-0.1.5.tgz",
     "@lvce-editor/server": "0.100.17",
     "eslint": "^10.8.1",
     "knip": "^6.32.2",


### PR DESCRIPTION
## What

Package notification-center-view 0.1.5 with its direct renderer-process connection for live updates.

## Validation

- 168 tests
- type check, lint, build