### PR TITLE
fix: investigate flaky about shift-tab e2e

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,11 +7,12 @@ on:
 
 jobs:
   pr:
+    name: Firefox e2e attempt ${{ matrix.attempt }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2025]
-    runs-on: ${{ matrix.os }}
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -65,3 +66,10 @@ jobs:
         run: npm run measure
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Upload e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: about-view-e2e-attempt-${{ matrix.attempt }}
+          path: ./.tmp/dist
+          if-no-files-found: warn


### PR DESCRIPTION
Investigates the intermittent Firefox failure in about.keyboard-shift-tab by running the existing macOS e2e job in 20 isolated attempts.