### PR TITLE
fix: use branded about dialog title

### DIFF
--- a/packages/about-view/src/parts/ShowAboutElectron/ShowAboutElectron.ts
+++ b/packages/about-view/src/parts/ShowAboutElectron/ShowAboutElectron.ts
@@ -15,6 +15,7 @@ export const showAboutElectron = async (): Promise<void> => {
     detail,
     message: productName,
     productName,
+    title: productName,
     type: ElectronMessageBoxType.Info,
     windowId,
   }

--- a/packages/about-view/test/ShowAboutElectron.test.ts
+++ b/packages/about-view/test/ShowAboutElectron.test.ts
@@ -55,6 +55,7 @@ const expectedOptions = {
   detail,
   message: 'Configured Editor',
   productName: 'Configured Editor',
+  title: 'Configured Editor',
   type: 'info',
   windowId: 1,
 }


### PR DESCRIPTION
Use the configured product name as the explicit native About dialog title so production builds do not fall back to OSS branding.